### PR TITLE
[Feat] 라우팅 설정, 메인 레이아웃 디자인 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,10 @@ import MainLayout from "@/layouts/MainLayout";
 import Home from "@/components/Home";
 import Score from "@/components/Score";
 import Activity from "@/components/Activity";
+import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
+import { ThemeProvider as EmotionThemeProvider } from "@emotion/react";
+import { theme } from "@/styles/theme";
+
 // TODO
 // 라우팅 경로 설정
 const router = createBrowserRouter([
@@ -19,7 +23,13 @@ const router = createBrowserRouter([
 ]);
 
 const App: React.FC = () => {
-  return <RouterProvider router={router} />;
+  return (
+    <MuiThemeProvider theme={theme}>
+      <EmotionThemeProvider theme={theme}>
+        <RouterProvider router={router} />
+      </EmotionThemeProvider>
+    </MuiThemeProvider>
+  );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,14 +2,19 @@ import React from "react";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import MainLayout from "@/layouts/MainLayout";
 import Home from "@/components/Home";
-
+import Score from "@/components/Score";
+import Activity from "@/components/Activity";
 // TODO
 // 라우팅 경로 설정
 const router = createBrowserRouter([
   {
     path: "/",
     element: <MainLayout />,
-    children: [{ path: "/", element: <Home /> }],
+    children: [
+      { path: "/", element: <Home /> },
+      { path: "/score", element: <Score /> },
+      { path: "/activity", element: <Activity /> },
+    ],
   },
 ]);
 

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -8,7 +8,7 @@ const wrapperStyle = css`
   height: 100%;
 `;
 
-const Home: React.FC = () => {
+const Activity: React.FC = () => {
   return (
     <div css={wrapperStyle}>
       <div
@@ -17,10 +17,10 @@ const Home: React.FC = () => {
           font-size: 24px;
         `}
       >
-        홈 페이지 (SCUPI 서비스 소개?)
+        활동 페이지 (활동 제출, 활동 승인/거부)
       </div>
     </div>
   );
 };
 
-export default Home;
+export default Activity;

--- a/src/components/Activity.tsx
+++ b/src/components/Activity.tsx
@@ -1,16 +1,16 @@
-import { css } from "@emotion/react";
+import FlexBox from "@/styles/components/common/FlexBox";
+import { css, useTheme } from "@emotion/react";
 import React from "react";
 
-const wrapperStyle = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-`;
-
 const Activity: React.FC = () => {
+  const theme = useTheme();
   return (
-    <div css={wrapperStyle}>
+    <FlexBox
+      css={css`
+        ${theme.mixins.widthHeight()}
+      `}
+    >
+      {" "}
       <div
         css={css`
           color: black;
@@ -19,7 +19,7 @@ const Activity: React.FC = () => {
       >
         활동 페이지 (활동 제출, 활동 승인/거부)
       </div>
-    </div>
+    </FlexBox>
   );
 };
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,26 +1,26 @@
-import { css } from "@emotion/react";
+import FlexBox from "@/styles/components/common/FlexBox";
+import { css, useTheme } from "@emotion/react";
 import React from "react";
 
-const wrapperStyle = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-`;
-
-const Home: React.FC = () => {
+const Activity: React.FC = () => {
+  const theme = useTheme();
   return (
-    <div css={wrapperStyle}>
+    <FlexBox
+      css={css`
+        ${theme.mixins.widthHeight()}
+      `}
+    >
+      {" "}
       <div
         css={css`
           color: black;
           font-size: 24px;
         `}
       >
-        홈 페이지 (SCUPI 서비스 소개?)
+        홈 화면(서비스 소개 등등)
       </div>
-    </div>
+    </FlexBox>
   );
 };
 
-export default Home;
+export default Activity;

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -8,7 +8,7 @@ const wrapperStyle = css`
   height: 100%;
 `;
 
-const Home: React.FC = () => {
+const Score: React.FC = () => {
   return (
     <div css={wrapperStyle}>
       <div
@@ -17,10 +17,10 @@ const Home: React.FC = () => {
           font-size: 24px;
         `}
       >
-        홈 페이지 (SCUPI 서비스 소개?)
+        통계 페이지
       </div>
     </div>
   );
 };
 
-export default Home;
+export default Score;

--- a/src/components/Score.tsx
+++ b/src/components/Score.tsx
@@ -1,16 +1,16 @@
-import { css } from "@emotion/react";
+import FlexBox from "@/styles/components/common/FlexBox";
+import { css, useTheme } from "@emotion/react";
 import React from "react";
 
-const wrapperStyle = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100%;
-`;
-
-const Score: React.FC = () => {
+const Activity: React.FC = () => {
+  const theme = useTheme();
   return (
-    <div css={wrapperStyle}>
+    <FlexBox
+      css={css`
+        ${theme.mixins.widthHeight()}
+      `}
+    >
+      {" "}
       <div
         css={css`
           color: black;
@@ -19,8 +19,8 @@ const Score: React.FC = () => {
       >
         통계 페이지
       </div>
-    </div>
+    </FlexBox>
   );
 };
 
-export default Score;
+export default Activity;

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #ffffffd0;
+  background-color: #f4f4f4;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,6 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
   background-color: #f4f4f4;
 
   font-synthesis: none;

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router-dom";
 import { css } from "@emotion/react";
 import NavBar from "@/layouts/NavBar";
 import TopBar from "@/layouts/TopBar";
+import FlexBox from "@/styles/components/common/FlexBox";
 
 const layoutStyle = css`
   display: flex;
@@ -11,9 +12,7 @@ const layoutStyle = css`
 
 const contentWrapperStyle = css`
   flex-grow: 1;
-  display: flex;
   flex-direction: column;
-  align-items: center;
   padding: 16px;
 `;
 
@@ -32,12 +31,12 @@ const MainLayout: React.FC = () => {
   return (
     <div css={layoutStyle}>
       <NavBar />
-      <div css={contentWrapperStyle}>
+      <FlexBox css={contentWrapperStyle}>
         <div css={contentStyle}>
           <TopBar />
           <Outlet />
         </div>
-      </div>
+      </FlexBox>
     </div>
   );
 };

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,9 +1,37 @@
+/** @jsxImportSource @emotion/react */
 import { Outlet } from "react-router-dom";
+import { css } from "@emotion/react";
+import NavBar from "@/layouts/NavBar";
+import TopBar from "@/layouts/TopBar";
 
-const MainLayout = () => {
+const layoutStyle = css`
+  display: flex;
+  height: 100vh;
+`;
+
+const contentWrapperStyle = css`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+const contentStyle = css`
+  flex-grow: 1;
+  padding: 24px;
+  background-color: #ffffff;
+  overflow-y: auto;
+`;
+
+const MainLayout: React.FC = () => {
   return (
-    <div>
-      <Outlet />
+    <div css={layoutStyle}>
+      <NavBar />
+      <div css={contentWrapperStyle}>
+        <TopBar />
+        <div css={contentStyle}>
+          <Outlet />
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -13,13 +13,19 @@ const contentWrapperStyle = css`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  padding: 16px;
 `;
 
 const contentStyle = css`
   flex-grow: 1;
-  padding: 24px;
+  width: 100%;
   background-color: #ffffff;
+  border-radius: 24px;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 `;
 
 const MainLayout: React.FC = () => {
@@ -27,8 +33,8 @@ const MainLayout: React.FC = () => {
     <div css={layoutStyle}>
       <NavBar />
       <div css={contentWrapperStyle}>
-        <TopBar />
         <div css={contentStyle}>
+          <TopBar />
           <Outlet />
         </div>
       </div>

--- a/src/layouts/NavBar.tsx
+++ b/src/layouts/NavBar.tsx
@@ -20,7 +20,7 @@ import {
 
 const sidebarStyle = css`
   width: 250px;
-  height: 100vh;
+  height: 100%;
   background-color: #f4f4f4;
   color: black;
   display: flex;

--- a/src/layouts/NavBar.tsx
+++ b/src/layouts/NavBar.tsx
@@ -1,0 +1,145 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { useNavigate } from "react-router-dom";
+import {
+  Drawer,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+import {
+  Home as HomeIcon,
+  Dashboard as DashboardIcon,
+  EmojiEvents as ActivityIcon,
+  Info as InfoIcon,
+  Settings as SettingsIcon,
+} from "@mui/icons-material";
+
+// Emotion CSS
+
+const sidebarStyle = css`
+  width: 250px;
+  height: 100vh;
+  background-color: #f4f4f4;
+  color: black;
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+`;
+
+const logoStyle = css`
+  font-size: 30px;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  text-align: center;
+  color: green;
+`;
+
+const menuContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding-bottom: 8px;
+  justify-content: space-between;
+`;
+
+const listItemStyle = css`
+  color: black;
+  padding: 10px 16px;
+  border-radius: 16px;
+  transition: background-color 0.3s ease-in-out;
+  &:hover {
+    background-color: rgba(0, 128, 0, 0.1);
+  }
+`;
+
+const iconStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  transition: background-color 0.3s ease-in-out;
+`;
+
+const textStyle = css`
+  padding: 5px 10px;
+  border-radius: 8px;
+  transition: background-color 0.3s ease-in-out;
+`;
+
+// 메뉴 배열
+const menuMainItems = [
+  { title: "Home", icon: <HomeIcon />, path: "/" },
+  { title: "Score", icon: <DashboardIcon />, path: "/score" },
+  { title: "Activity", icon: <ActivityIcon />, path: "/activity" },
+];
+
+const menuSubItems = [
+  { title: "Settings", icon: <SettingsIcon />, path: "/settings" },
+  { title: "about", icon: <InfoIcon />, path: "/about" },
+];
+
+// NavBar 컴포넌트
+const NavBar: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Drawer
+      variant="permanent"
+      css={sidebarStyle}
+      sx={{
+        "& .MuiDrawer-paper": {
+          width: 250,
+          padding: "8px",
+          height: "100vh",
+          backgroundColor: "#f4f4f4",
+          color: "black",
+          borderRight: "none",
+          boxShadow: "none",
+        },
+      }}
+    >
+      <Typography css={logoStyle}>SKKU SCUPI</Typography>
+      {/* 일반 메뉴 */}
+      <div css={menuContainerStyle}>
+        <List>
+          {menuMainItems.map(({ title, icon, path }) => (
+            <ListItem
+              button
+              key={title}
+              onClick={() => navigate(path)}
+              css={listItemStyle}
+            >
+              <span css={iconStyle}>{icon}</span>
+              <span css={textStyle}>
+                <ListItemText primary={title} />
+              </span>
+            </ListItem>
+          ))}
+        </List>
+        {/* 추가 메뉴 */}
+        <List>
+          {menuSubItems.map(({ title, icon, path }) => (
+            <ListItem
+              button
+              key={title}
+              onClick={() => navigate(path)}
+              css={listItemStyle}
+            >
+              <span css={iconStyle}>{icon}</span>
+              <span css={textStyle}>
+                <ListItemText primary={title} />
+              </span>
+            </ListItem>
+          ))}
+        </List>
+      </div>
+    </Drawer>
+  );
+};
+
+export default NavBar;

--- a/src/layouts/TopBar.tsx
+++ b/src/layouts/TopBar.tsx
@@ -2,6 +2,7 @@
 import { css } from "@emotion/react";
 import { IconButton, Typography, Paper } from "@mui/material";
 import LogoutIcon from "@mui/icons-material/Logout";
+import FlexBox from "@/styles/components/common/FlexBox";
 
 const topBarStyle = css`
   width: 100%;
@@ -15,8 +16,6 @@ const topBarStyle = css`
 `;
 
 const userInfoWrapperStyle = css`
-  display: flex;
-  align-items: center;
   margin: 0 30px;
   gap: 16px;
 `;
@@ -39,7 +38,7 @@ const data = {
 const TopBar: React.FC = () => {
   return (
     <Paper elevation={1} css={topBarStyle}>
-      <div css={userInfoWrapperStyle}>
+      <FlexBox css={userInfoWrapperStyle}>
         <div css={userInfoStyle}>
           <Typography variant="body1" fontWeight="bold">
             {data.user_name}
@@ -61,7 +60,7 @@ const TopBar: React.FC = () => {
         >
           <LogoutIcon />
         </IconButton>
-      </div>
+      </FlexBox>
     </Paper>
   );
 };

--- a/src/layouts/TopBar.tsx
+++ b/src/layouts/TopBar.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource @emotion/react */
+import { css } from "@emotion/react";
+import { IconButton, Typography, Paper } from "@mui/material";
+import LogoutIcon from "@mui/icons-material/Logout";
+
+const topBarStyle = css`
+  width: 100%;
+  height: 60px;
+  background-color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.05);
+  z-index: 100;
+`;
+
+const userInfoWrapperStyle = css`
+  display: flex;
+  align-items: center;
+  margin: 0 30px;
+  gap: 16px;
+`;
+
+const userInfoStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+`;
+
+// data
+const data = {
+  user_role: "student",
+  user_name: "강병희",
+  user_hakbun: "2020123456",
+  user_hakbun_cd: "CS201",
+  user_year: "2",
+};
+
+const TopBar: React.FC = () => {
+  return (
+    <Paper elevation={1} css={topBarStyle}>
+      <div css={userInfoWrapperStyle}>
+        <div css={userInfoStyle}>
+          <Typography variant="body1" fontWeight="bold">
+            {data.user_name}
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            {data.user_hakbun}
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            {data.user_hakbun_cd}
+          </Typography>
+          <Typography variant="body2" color="textSecondary">
+            {data.user_role}
+          </Typography>
+        </div>
+        <IconButton
+          css={css`
+            color: green;
+          `}
+        >
+          <LogoutIcon />
+        </IconButton>
+      </div>
+    </Paper>
+  );
+};
+
+export default TopBar;

--- a/src/styles/components/common/FlexBox.tsx
+++ b/src/styles/components/common/FlexBox.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+const FlexBox = styled.div<{
+  justify?: string;
+  align?: string;
+  direction?: string;
+  gap?: string;
+}>`
+  ${({ theme, direction = "row", align = "center", justify = "center" }) =>
+    theme.mixins.flexBox({ direction, align, justify })};
+  gap: ${({ gap }) => gap || "0"};
+`;
+
+export default FlexBox;

--- a/src/styles/mixins.ts
+++ b/src/styles/mixins.ts
@@ -1,0 +1,18 @@
+import { css } from "@emotion/react";
+
+export const mixins = {
+  flexBox: ({
+    direction = "row",
+    align = "center",
+    justify = "center",
+  } = {}) => css`
+    display: flex;
+    flex-direction: ${direction};
+    align-items: ${align};
+    justify-content: ${justify};
+  `,
+  widthHeight: ({ width = "100%", height = "100%" } = {}) => css`
+    width: ${width};
+    height: ${height};
+  `,
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,30 @@
+// theme.ts
+import { mixins } from "./mixins";
+import { createTheme } from "@mui/material";
+
+const customTheme = {
+  customColors: {},
+  customSpacing: {
+    small: "8px",
+    medium: "16px",
+    large: "32px",
+  },
+  customFontSize: {
+    small: "14px",
+    medium: "16px",
+    large: "20px",
+  },
+  customBorderRadius: {
+    small: "4px",
+    medium: "8px",
+    large: "16px",
+  },
+  mixins,
+};
+
+const muiTheme = createTheme();
+
+export const theme = {
+  ...muiTheme,
+  ...customTheme,
+};

--- a/src/types/emotion.d.ts
+++ b/src/types/emotion.d.ts
@@ -1,0 +1,9 @@
+// src/types/emotion.d.ts
+import "@emotion/react";
+import { theme } from "@/styles/theme";
+
+type AppTheme = typeof theme;
+
+declare module "@emotion/react" {
+  export interface Theme extends AppTheme {}
+}


### PR DESCRIPTION
1. 라우팅 설정
- RouterProvider를 이용하여 라우터 셋팅을 해두었습니다. MainLayout은 공통으로 가져가고 페이지별로 개발하면서 경로 추가할 예정입니다.
- setting과 info등은 아직 확정은 아니라서 네비게이션바에 넣어뒀는데 라우팅이랑 컴포넌트 생성은 하지 않았습니다. 추후 회의를 통해 추가할 요소들이나 디자인이 좀 더 확정되면 추가하도록 하겠습니다.

2. 메인 레이아웃 설정
- 아래와 같은 카드형 디자인을 레퍼런스로 삼아서 보여줘야 할 통계량을 여러 그래프로 볼 수 있도록 개발할 예정입니다.
&ensp; <details>
&ensp;<summary>디자인 레퍼런스</summary>
&ensp;<img width="500" alt="레퍼런스1" src="https://github.com/user-attachments/assets/75fa74a2-ef30-4590-8e2e-4ecbef272f6a" />
&ensp;<img width="500" alt="레퍼런스2" src="https://github.com/user-attachments/assets/fb328e1c-8931-40f0-a15e-0f8560600658" />
&ensp;</details>
