### PR TITLE
Feature/#15 권한, 로그인 관련 컴포넌트 추가

### DIFF
--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import useUserStore from "@/stores/auth/userStore";
+import { Navigate, Outlet } from "react-router-dom";
+
+interface ProtectedRouteProps {
+  allowedRoles: number[];
+}
+const ProtectedRoute = ({ allowedRoles }: ProtectedRouteProps) => {
+  const { user_id, user_role } = useUserStore();
+
+  if (!user_id) {
+    // 알림 띄우고 로그인 페이지로 리다이렉트
+    alert("로그인이 필요합니다. 로그인 페이지로 이동합니다.");
+    return <Navigate to="/login" replace />;
+  }
+
+  if (user_role && !allowedRoles.includes(user_role)) {
+    // 알림 띄우고 메인으로 리다이렉트
+    alert("권한이 없습니다. 메인 페이지로 이동합니다.");
+    return <Navigate to="/" replace />;
+  }
+  return <Outlet />;
+};

--- a/src/components/layouts/NavBar.tsx
+++ b/src/components/layouts/NavBar.tsx
@@ -55,7 +55,8 @@ const NavBar: React.FC = () => {
   const { selectedTab, toggleTab } = useNavigationStore();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const user_role = useUserStore().user_role;
+  const { user_hakbun, user_name, user_role, setUser, clearUser } =
+    useUserStore();
 
   // 토글 시 자동으로 default 페이지로 이동
   const handleToggle = () => {
@@ -65,6 +66,23 @@ const NavBar: React.FC = () => {
         ? "/activities/dashboard"
         : "/statistics/dashboard"
     );
+  };
+
+  const handleLogin = () => {
+    setUser({
+      user_id: 1,
+      user_role: 0,
+      user_name: "홍길동",
+      user_hakbun: "2020123456",
+      user_hakgwa_cd: "CS",
+      user_year: 2020,
+    });
+    setAnchorEl(null);
+  };
+
+  const handleLogout = () => {
+    clearUser();
+    setAnchorEl(null);
   };
 
   return (
@@ -164,8 +182,17 @@ const NavBar: React.FC = () => {
 
         {/* 프로필 부분 */}
         <FlexBox justify="flex-end" gap="16px">
-          <span>2020123456</span>
-          <span>홍길동</span>
+          <span>{user_hakbun}</span>
+          <span>{user_name}</span>
+          <span>
+            {user_role === null
+              ? "로그인전"
+              : user_role === 0
+              ? "학생"
+              : user_role === 1
+              ? "관리자"
+              : "슈퍼관리자"}
+          </span>
           <IconButton
             onClick={(e) => setAnchorEl(e.currentTarget)}
             size="small"
@@ -193,6 +220,8 @@ const NavBar: React.FC = () => {
                 {label}
               </MenuItem>
             ))}
+            <MenuItem onClick={handleLogin}>로그인</MenuItem>
+            <MenuItem onClick={handleLogout}>로그아웃</MenuItem>
           </Menu>
         </FlexBox>
       </FlexBox>

--- a/src/pages/auth/Login.tsx
+++ b/src/pages/auth/Login.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+const Login: React.FC = () => {
+  return (
+    <div
+      css={css`
+        padding: 20px;
+      `}
+    >
+      <h1>Login Page</h1>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/stores/auth/userStore.ts
+++ b/src/stores/auth/userStore.ts
@@ -1,21 +1,36 @@
 import { create } from "zustand";
 
 interface UserStore {
-  user_id: number;
-  user_role: 0 | 1 | 2;
-  user_name: string;
-  user_hakbun: string;
-  user_hakgwa_cd: string;
-  user_year: number;
+  user_id: number | null;
+  user_role: 0 | 1 | 2 | null;
+  user_name: string | null;
+  user_hakbun: string | null;
+  user_hakgwa_cd: string | null;
+  user_year: number | null;
 }
 
-const useUserStore = create<UserStore>((set) => ({
-  user_id: 0,
-  user_role: 0,
-  user_name: "김민수",
-  user_hakbun: "2020123456",
-  user_hakgwa_cd: "CS201",
-  user_year: 1.5,
+interface UserStoreActions {
+  setUser: (user: UserStore) => void;
+  clearUser: () => void;
+}
+
+const useUserStore = create<UserStore & UserStoreActions>((set) => ({
+  user_id: null,
+  user_role: null,
+  user_name: null,
+  user_hakbun: null,
+  user_hakgwa_cd: null,
+  user_year: null,
+  setUser: (user: UserStore) => set(user),
+  clearUser: () =>
+    set({
+      user_id: null,
+      user_role: null,
+      user_name: null,
+      user_hakbun: null,
+      user_hakgwa_cd: null,
+      user_year: null,
+    }),
 }));
 
 export default useUserStore;


### PR DESCRIPTION
## 📌 PR 개요

권한과 로그인에 따른 분기를 위한 컴포넌트와 테스트용 컴포넌트를 추가했습니다.

## 🛠 작업 내용

- [x] 권한과 로그인 여부를 확인하는 전역 ProtectedRoute 컴포넌트 추가
여기서는 하위 컴포넌트가 렌더링되기 전에 로그인 여부와 하위컴포넌트에 필요한 권한 여부를 확인하여 적절한 페이지로 리디렉션시킵니다
- [x] 로그인 테스트용 토글 컴포넌트 추가
백엔드와 연결하기 전 로그인 관련 기능을 테스트 하기 위해서 토글에 로그인/로그아웃 버튼을 눌러 테스트를 할 수 있게 만들었습니다.
이 요소는 백엔드와 연결한 후 제거할 예정입니다.

## 🖼 스크린샷 (선택)
![스크린샷 2025-04-10 오후 3 45 27](https://github.com/user-attachments/assets/a3998e20-d0ca-463b-9d84-eba98870e628)
위와 같이 토글에서 권한이나 로그인 여부를 쉽게 변경해서 테스트할 수 있도록 만들었습니다.

## 🔗 연관된 이슈
- closes #15 
