### PR TITLE
관리자 활동 대시보드 제작

### DIFF
--- a/src/components/graphs/SimpleChart.tsx
+++ b/src/components/graphs/SimpleChart.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+
+interface ChartDataItem {
+  name: string;
+  value: number;
+}
+
+interface SimpleChartProps {
+  data: ChartDataItem[];
+}
+
+const SimpleChart: React.FC<SimpleChartProps> = ({ data }) => {
+  // 각 바의 높이와 간격을 설정
+  const barHeight = 30;
+  const barGap = 40;
+  const baseHeight = 120;
+
+  // 전체 높이 계산: (바 높이 + 간격) * 데이터 수 + 기본 여백
+  const totalHeight = (barHeight + barGap) * data.length + baseHeight;
+
+  return (
+    <ResponsiveContainer width="100%" height={totalHeight}>
+      <BarChart
+        data={data}
+        layout="vertical"
+        margin={{
+          top: 20,
+          right: 30,
+          left: 60,
+          bottom: 5,
+        }}
+      >
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis type="number" />
+        <YAxis
+          dataKey="name"
+          type="category"
+          width={100}
+          tick={{ fontSize: 14 }}
+        />
+        <Tooltip />
+        <Bar dataKey="value" fill="#000000" barSize={barHeight} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default SimpleChart;

--- a/src/components/graphs/SimplePieChart.tsx
+++ b/src/components/graphs/SimplePieChart.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+interface ChartDataItem {
+  name: string;
+  value: number;
+  color: string;
+}
+
+interface SimplePieChartProps {
+  data: ChartDataItem[];
+  width?: number | string;
+  height?: number | string;
+}
+
+const SimplePieChart: React.FC<SimplePieChartProps> = ({
+  data,
+  width = "100%",
+  height = 400,
+}) => {
+  return (
+    <ResponsiveContainer width={width} height={height}>
+      <PieChart>
+        <Pie
+          data={data}
+          cx="50%"
+          cy="50%"
+          labelLine={false}
+          outerRadius={150}
+          fill="#8884d8"
+          dataKey="value"
+          label={({ name, percent }) =>
+            `${name} (${(percent * 100).toFixed(1)}%)`
+          }
+        >
+          {data.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.color} />
+          ))}
+        </Pie>
+        <Tooltip formatter={(value: number) => [`${value}건`, "제출"]} />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default SimplePieChart;

--- a/src/pages/admin/activiy/dashboard/components/QuotientCard.tsx
+++ b/src/pages/admin/activiy/dashboard/components/QuotientCard.tsx
@@ -1,0 +1,75 @@
+/** @jsxImportSource @emotion/react */
+import FlexBox from "@/styles/components/Flexbox";
+import { css } from "@emotion/react";
+
+interface QuotientCardProps {
+  color: string;
+  title: string;
+  month: number;
+  change: number;
+  total: number;
+}
+
+const containerStyle = css`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  margin-right: 10px;
+`;
+
+const titleStyle = css`
+  font-size: 1.5rem;
+  font-weight: bold;
+`;
+
+const categoryStyle = css`
+  font-size: 1rem;
+  font-weight: 500;
+  color: #888;
+`;
+
+const valueStyle = css`
+  font-size: 1rem;
+  font-weight: 600;
+`;
+
+export const QuotientCard = ({
+  color,
+  title,
+  month,
+  change,
+  total,
+}: QuotientCardProps) => {
+  const isPositive = change >= 0;
+  const changeColor = isPositive ? "#00C49F" : "#FF6B6B";
+  return (
+    <div css={containerStyle} style={{ borderLeft: `6px solid ${color}` }}>
+      <FlexBox
+        direction="column"
+        align="flex-start"
+        gap="10px"
+        css={{ paddingRight: "20px" }}
+      >
+        <div css={titleStyle}>{title}</div>
+        <FlexBox align="flex-start" justify="space-between">
+          <div>
+            <div css={categoryStyle}>이번 달</div>
+            <div css={valueStyle}>{month}건</div>
+          </div>
+          <div>
+            <div css={categoryStyle}>전월 대비</div>
+            <div css={valueStyle} style={{ color: changeColor }}>
+              {isPositive ? "▲" : "▼"} {Math.abs(change)}%
+            </div>
+          </div>
+          <div>
+            <div css={categoryStyle}>총 제출</div>
+            <div css={valueStyle}>{total}건</div>
+          </div>
+        </FlexBox>
+      </FlexBox>
+    </div>
+  );
+};

--- a/src/pages/admin/activiy/dashboard/index.tsx
+++ b/src/pages/admin/activiy/dashboard/index.tsx
@@ -1,14 +1,186 @@
 import React from "react";
 import { css } from "@emotion/react";
+import FlexBox from "@/styles/components/Flexbox";
+import GraphWrapper from "@/components/graphs/GraphWrapper";
+import Card from "@/styles/components/Card";
+import SimpleChart from "@/components/graphs/SimpleChart";
+
+const titleStyle = css`
+  font-size: 2.5rem;
+  font-weight: bold;
+`;
+
+const subtitleStyle = css`
+  font-size: 1.8rem;
+`;
+
+const LQdata = {
+  교육활동: [
+    { name: "교육외의 교육 활동", value: 10 },
+    { name: "교육 조교 활동", value: 20 },
+  ],
+  "교육 성취도": [
+    { name: "학점 4.0~4.5", value: 10 },
+    { name: "학점 3.5~4.0", value: 20 },
+    { name: "학점 3.0~3.5", value: 30 },
+  ],
+  "오픈소스 SW 활동": [
+    { name: "OS 커뮤니티 생성 및 활성도 5점", value: 10 },
+    { name: "OS 커뮤니티 참여 및 활성도 4점", value: 20 },
+    { name: "OS 커뮤니티 참여 및 활성도 3점", value: 30 },
+    { name: "커미터로서의 활동 5점", value: 40 },
+    { name: "커미터로서의 활동 4점", value: 50 },
+    { name: "커미터로서의 활동 3점", value: 60 },
+  ],
+};
+
+const RQdata = {
+  "학술지 논문게재": [
+    { name: "SCI, SSCI, A&HCI 급 학술지", value: 10 },
+    { name: "KCI 우수등재 학술지", value: 5 },
+    { name: "KCI 등재", value: 3 },
+    { name: "KCI 후보, 기타국제", value: 2 },
+  ],
+  "학술대회 발표": [
+    { name: "저명 국제학술대회 발표", value: 10 },
+    { name: "저명 국제학술대회 발표(BK기준 4점)", value: 4 },
+    { name: "일반 국제학술대회 발표", value: 2 },
+    { name: "국내학술대회 발표", value: 1 },
+  ],
+  "공모전/ICPC": [
+    { name: "국제/대규모 공모전(대상/입상)", value: 10 },
+    { name: "국제/대규모 공모전(참여)", value: 2 },
+    { name: "교내/지역 공모전(대상/입상)", value: 3 },
+    { name: "교내/지역 공모전(참여)", value: 0.5 },
+  ],
+};
+
+const CQdata = {
+  산학프로젝트: [
+    { name: "수행여부", value: 2 },
+    { name: "평가점수 A", value: 5 },
+    { name: "평가점수 B", value: 3 },
+    { name: "평가점수 C", value: 1 },
+  ],
+  인턴십: [
+    { name: "수행여부", value: 2 },
+    { name: "평가점수 A", value: 5 },
+    { name: "평가점수 B", value: 3 },
+    { name: "평가점수 C", value: 1 },
+  ],
+  창업: [{ name: "수행여부", value: 30 }],
+  해외봉사: [
+    { name: "수행여부", value: 10 },
+    { name: "평가점수 A", value: 5 },
+    { name: "평가점수 B", value: 3 },
+    { name: "평가점수 C", value: 1 },
+  ],
+  "화상강연/세미나 참여": [{ name: "수행여부", value: 1 }],
+  알리미: [
+    { name: "회장", value: 20 },
+    { name: "부회장", value: 15 },
+    { name: "임원진", value: 10 },
+    { name: "참여", value: 5 },
+  ],
+  학생회: [
+    { name: "회장", value: 20 },
+    { name: "부회장", value: 15 },
+    { name: "임원진", value: 10 },
+    { name: "참여", value: 5 },
+  ],
+  SCG: [
+    { name: "회장", value: 10 },
+    { name: "부회장", value: 8 },
+    { name: "임원진", value: 6 },
+    { name: "참여", value: 5 },
+  ],
+  미디어홍보: [
+    { name: "회장", value: 10 },
+    { name: "부회장", value: 8 },
+    { name: "임원진", value: 6 },
+    { name: "참여", value: 5 },
+  ],
+  스튜디오기여: [{ name: "참여", value: 2 }],
+  스터디그룹: [
+    { name: "회장", value: 5 },
+    { name: "참여", value: 2 },
+  ],
+};
 
 const AdminActivityDashboard: React.FC = () => {
   return (
-    <div
-      css={css`
-        padding: 20px;
-      `}
-    >
-      <h1>Admin Activities Dashboard</h1>
+    <div css={{ marginBottom: "200px" }}>
+      <h1 css={titleStyle}>활동 대시보드</h1>
+      <FlexBox justify="space-between">
+        <h2 css={subtitleStyle}>3Q 영역별 활동 현황</h2>
+        <button>검색 필터</button>
+      </FlexBox>
+      <FlexBox justify="space-between">
+        <Card>test</Card>
+        <Card>test</Card>
+        <Card>test</Card>
+      </FlexBox>
+
+      <div>
+        <GraphWrapper
+          title="교육지표 (Learning Quotient)"
+          type="block"
+          options={{
+            labels: ["교육활동", "교육성취도", "오픈소스SW활동"],
+            datasets: {
+              교육활동: <SimpleChart data={LQdata["교육활동"]} />,
+              교육성취도: <SimpleChart data={LQdata["교육 성취도"]} />,
+              오픈소스SW활동: <SimpleChart data={LQdata["오픈소스 SW 활동"]} />,
+            },
+          }}
+        />
+        <GraphWrapper
+          title="학술지표 (Research Quotient)"
+          type="block"
+          options={{
+            labels: ["학술지 논문게재", "학술대회 발표", "공모전/ICPC"],
+            datasets: {
+              "학술지 논문게재": (
+                <SimpleChart data={RQdata["학술지 논문게재"]} />
+              ),
+              "학술대회 발표": <SimpleChart data={RQdata["학술대회 발표"]} />,
+              "공모전/ICPC": <SimpleChart data={RQdata["공모전/ICPC"]} />,
+            },
+          }}
+        />
+        <GraphWrapper
+          title="교류지표 Communication Quotient"
+          type="dropdown"
+          options={{
+            labels: [
+              "산학협력프로젝트",
+              "인턴쉽",
+              "창업",
+              "해외봉사",
+              "화상강연/세미나",
+              "알리미",
+              "학생회",
+              "SCG",
+              "미디어홍보",
+              "스튜디오 기여",
+              "스터디그룹",
+            ],
+            datasets: {
+              산학협력프로젝트: <SimpleChart data={CQdata["산학프로젝트"]} />,
+              인턴쉽: <SimpleChart data={CQdata["인턴십"]} />,
+              창업: <SimpleChart data={CQdata["창업"]} />,
+              해외봉사: <SimpleChart data={CQdata["해외봉사"]} />,
+              화상강연세미나: (
+                <SimpleChart data={CQdata["화상강연/세미나 참여"]} />
+              ),
+              알리미: <SimpleChart data={CQdata["알리미"]} />,
+              학생회: <SimpleChart data={CQdata["학생회"]} />,
+              SCG: <SimpleChart data={CQdata["SCG"]} />,
+              미디어홍보: <SimpleChart data={CQdata["미디어홍보"]} />,
+            },
+          }}
+        />
+      </div>
     </div>
   );
 };

--- a/src/pages/admin/activiy/dashboard/index.tsx
+++ b/src/pages/admin/activiy/dashboard/index.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import { css } from "@emotion/react";
 import FlexBox from "@/styles/components/Flexbox";
 import GraphWrapper from "@/components/graphs/GraphWrapper";
-import Card from "@/styles/components/Card";
 import SimpleChart from "@/components/graphs/SimpleChart";
-
+import SimplePieChart from "@/components/graphs/SimplePieChart";
+import Card from "@/styles/components/Card";
+import { QuotientCard } from "./components/QuotientCard";
 const titleStyle = css`
   font-size: 2.5rem;
   font-weight: bold;
@@ -14,98 +15,149 @@ const subtitleStyle = css`
   font-size: 1.8rem;
 `;
 
+const filterButtonStyle = css`
+  padding: 8px 16px;
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &:hover {
+    background-color: #e8e8e8;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  }
+`;
+
+// 더미 데이터
 const LQdata = {
   교육활동: [
-    { name: "교육외의 교육 활동", value: 10 },
-    { name: "교육 조교 활동", value: 20 },
+    { name: "교육외의 교육 활동", value: 15 },
+    { name: "교육 조교 활동", value: 25 },
   ],
   "교육 성취도": [
-    { name: "학점 4.0~4.5", value: 10 },
-    { name: "학점 3.5~4.0", value: 20 },
-    { name: "학점 3.0~3.5", value: 30 },
+    { name: "학점 4.0~4.5", value: 18 },
+    { name: "학점 3.5~4.0", value: 12 },
+    { name: "학점 3.0~3.5", value: 22 },
   ],
   "오픈소스 SW 활동": [
-    { name: "OS 커뮤니티 생성 및 활성도 5점", value: 10 },
-    { name: "OS 커뮤니티 참여 및 활성도 4점", value: 20 },
-    { name: "OS 커뮤니티 참여 및 활성도 3점", value: 30 },
-    { name: "커미터로서의 활동 5점", value: 40 },
-    { name: "커미터로서의 활동 4점", value: 50 },
-    { name: "커미터로서의 활동 3점", value: 60 },
+    { name: "OS 커뮤니티 생성 및 활성도 5점", value: 14 },
+    { name: "OS 커뮤니티 참여 및 활성도 4점", value: 28 },
+    { name: "OS 커뮤니티 참여 및 활성도 3점", value: 35 },
+    { name: "커미터로서의 활동 5점", value: 47 },
+    { name: "커미터로서의 활동 4점", value: 32 },
+    { name: "커미터로서의 활동 3점", value: 53 },
   ],
 };
 
 const RQdata = {
   "학술지 논문게재": [
-    { name: "SCI, SSCI, A&HCI 급 학술지", value: 10 },
-    { name: "KCI 우수등재 학술지", value: 5 },
-    { name: "KCI 등재", value: 3 },
-    { name: "KCI 후보, 기타국제", value: 2 },
+    { name: "SCI, SSCI, A&HCI 급 학술지", value: 12 },
+    { name: "KCI 우수등재 학술지", value: 8 },
+    { name: "KCI 등재", value: 6 },
+    { name: "KCI 후보, 기타국제", value: 4 },
   ],
   "학술대회 발표": [
-    { name: "저명 국제학술대회 발표", value: 10 },
-    { name: "저명 국제학술대회 발표(BK기준 4점)", value: 4 },
-    { name: "일반 국제학술대회 발표", value: 2 },
-    { name: "국내학술대회 발표", value: 1 },
+    { name: "저명 국제학술대회 발표", value: 13 },
+    { name: "저명 국제학술대회 발표(BK기준 4점)", value: 7 },
+    { name: "일반 국제학술대회 발표", value: 5 },
+    { name: "국내학술대회 발표", value: 3 },
   ],
   "공모전/ICPC": [
-    { name: "국제/대규모 공모전(대상/입상)", value: 10 },
-    { name: "국제/대규모 공모전(참여)", value: 2 },
-    { name: "교내/지역 공모전(대상/입상)", value: 3 },
-    { name: "교내/지역 공모전(참여)", value: 0.5 },
+    { name: "국제/대규모 공모전(대상/입상)", value: 15 },
+    { name: "국제/대규모 공모전(참여)", value: 4 },
+    { name: "교내/지역 공모전(대상/입상)", value: 6 },
+    { name: "교내/지역 공모전(참여)", value: 1.5 },
   ],
 };
 
 const CQdata = {
   산학프로젝트: [
-    { name: "수행여부", value: 2 },
-    { name: "평가점수 A", value: 5 },
-    { name: "평가점수 B", value: 3 },
-    { name: "평가점수 C", value: 1 },
+    { name: "수행여부", value: 4 },
+    { name: "평가점수 A", value: 7 },
+    { name: "평가점수 B", value: 5 },
+    { name: "평가점수 C", value: 2 },
   ],
   인턴십: [
-    { name: "수행여부", value: 2 },
-    { name: "평가점수 A", value: 5 },
-    { name: "평가점수 B", value: 3 },
-    { name: "평가점수 C", value: 1 },
+    { name: "수행여부", value: 3 },
+    { name: "평가점수 A", value: 8 },
+    { name: "평가점수 B", value: 6 },
+    { name: "평가점수 C", value: 2 },
   ],
-  창업: [{ name: "수행여부", value: 30 }],
+  창업: [{ name: "수행여부", value: 25 }],
   해외봉사: [
-    { name: "수행여부", value: 10 },
-    { name: "평가점수 A", value: 5 },
-    { name: "평가점수 B", value: 3 },
-    { name: "평가점수 C", value: 1 },
+    { name: "수행여부", value: 12 },
+    { name: "평가점수 A", value: 8 },
+    { name: "평가점수 B", value: 5 },
+    { name: "평가점수 C", value: 3 },
   ],
-  "화상강연/세미나 참여": [{ name: "수행여부", value: 1 }],
+  "화상강연/세미나 참여": [{ name: "수행여부", value: 2 }],
   알리미: [
-    { name: "회장", value: 20 },
-    { name: "부회장", value: 15 },
-    { name: "임원진", value: 10 },
-    { name: "참여", value: 5 },
+    { name: "회장", value: 8 },
+    { name: "부회장", value: 12 },
+    { name: "임원진", value: 7 },
+    { name: "참여", value: 3 },
   ],
   학생회: [
-    { name: "회장", value: 20 },
-    { name: "부회장", value: 15 },
-    { name: "임원진", value: 10 },
-    { name: "참여", value: 5 },
+    { name: "회장", value: 5 },
+    { name: "부회장", value: 10 },
+    { name: "임원진", value: 7 },
+    { name: "참여", value: 3 },
   ],
   SCG: [
-    { name: "회장", value: 10 },
-    { name: "부회장", value: 8 },
-    { name: "임원진", value: 6 },
-    { name: "참여", value: 5 },
+    { name: "회장", value: 15 },
+    { name: "부회장", value: 10 },
+    { name: "임원진", value: 7 },
+    { name: "참여", value: 4 },
   ],
   미디어홍보: [
-    { name: "회장", value: 10 },
-    { name: "부회장", value: 8 },
-    { name: "임원진", value: 6 },
-    { name: "참여", value: 5 },
+    { name: "회장", value: 12 },
+    { name: "부회장", value: 9 },
+    { name: "임원진", value: 5 },
+    { name: "참여", value: 3 },
   ],
-  스튜디오기여: [{ name: "참여", value: 2 }],
+  스튜디오기여: [{ name: "참여", value: 4 }],
   스터디그룹: [
-    { name: "회장", value: 5 },
-    { name: "참여", value: 2 },
+    { name: "회장", value: 7 },
+    { name: "참여", value: 3 },
   ],
 };
+
+const ratioData = [
+  { name: "LQ", value: 100, color: "#0088FE" },
+  { name: "RQ", value: 150, color: "#00C49F" },
+  { name: "CQ", value: 120, color: "#FFBB28" },
+];
+
+const summaryData = [
+  {
+    color: "#0088FE",
+    title: "Learning Quotient (LQ)",
+    month: 20,
+    change: 10,
+    total: 100,
+  },
+  {
+    color: "#00C49F",
+    title: "Research Quotient (RQ)",
+    month: 30,
+    change: -5,
+    total: 150,
+  },
+  {
+    color: "#FFBB28",
+    title: "Communication Quotient (CQ)",
+    month: 23,
+    change: 15,
+    total: 120,
+  },
+];
 
 const AdminActivityDashboard: React.FC = () => {
   return (
@@ -113,27 +165,26 @@ const AdminActivityDashboard: React.FC = () => {
       <h1 css={titleStyle}>활동 대시보드</h1>
       <FlexBox justify="space-between">
         <h2 css={subtitleStyle}>3Q 영역별 활동 현황</h2>
-        <button>검색 필터</button>
+        <button css={filterButtonStyle}>검색 필터</button>
       </FlexBox>
-      <FlexBox justify="space-between">
-        <Card>test</Card>
-        <Card>test</Card>
-        <Card>test</Card>
-      </FlexBox>
+      <Card>
+        <SimplePieChart data={ratioData} />
+        <FlexBox direction="column" gap="10px">
+          {summaryData.map((quotient, index) => (
+            <QuotientCard
+              key={index}
+              color={quotient.color}
+              title={quotient.title}
+              month={quotient.month}
+              change={quotient.change}
+              total={quotient.total}
+            />
+          ))}
+        </FlexBox>
+      </Card>
 
+      {/* TODO: data fetch 시 map 활용해서 단순화하기 */}
       <div>
-        <GraphWrapper
-          title="교육지표 (Learning Quotient)"
-          type="block"
-          options={{
-            labels: ["교육활동", "교육성취도", "오픈소스SW활동"],
-            datasets: {
-              교육활동: <SimpleChart data={LQdata["교육활동"]} />,
-              교육성취도: <SimpleChart data={LQdata["교육 성취도"]} />,
-              오픈소스SW활동: <SimpleChart data={LQdata["오픈소스 SW 활동"]} />,
-            },
-          }}
-        />
         <GraphWrapper
           title="학술지표 (Research Quotient)"
           type="block"
@@ -149,7 +200,19 @@ const AdminActivityDashboard: React.FC = () => {
           }}
         />
         <GraphWrapper
-          title="교류지표 Communication Quotient"
+          title="교육지표 (Learning Quotient)"
+          type="block"
+          options={{
+            labels: ["교육활동", "교육성취도", "오픈소스SW활동"],
+            datasets: {
+              교육활동: <SimpleChart data={LQdata["교육활동"]} />,
+              교육성취도: <SimpleChart data={LQdata["교육 성취도"]} />,
+              오픈소스SW활동: <SimpleChart data={LQdata["오픈소스 SW 활동"]} />,
+            },
+          }}
+        />
+        <GraphWrapper
+          title="교류지표 (Communication Quotient)"
           type="dropdown"
           options={{
             labels: [
@@ -177,6 +240,8 @@ const AdminActivityDashboard: React.FC = () => {
               학생회: <SimpleChart data={CQdata["학생회"]} />,
               SCG: <SimpleChart data={CQdata["SCG"]} />,
               미디어홍보: <SimpleChart data={CQdata["미디어홍보"]} />,
+              "스튜디오 기여": <SimpleChart data={CQdata["스튜디오기여"]} />,
+              스터디그룹: <SimpleChart data={CQdata["스터디그룹"]} />,
             },
           }}
         />

--- a/src/pages/admin/statistic/dashboard/index.tsx
+++ b/src/pages/admin/statistic/dashboard/index.tsx
@@ -61,7 +61,7 @@ const totalData = {
 const AdminStatisticDashboard: React.FC = () => {
   return (
     <div>
-      <h1 css={titleStyle}>대시보드</h1>
+      <h1 css={titleStyle}>통계 대시보드</h1>
 
       <div>
         <h2 css={subtitleStyle}>3Q 전체 통계</h2>

--- a/src/pages/admin/statistic/individual/index.tsx
+++ b/src/pages/admin/statistic/individual/index.tsx
@@ -178,7 +178,7 @@ const AdminStatisticIndividual: React.FC = () => {
       {/* 선택 유저 3Q 점수 차트 */}
       <GraphWrapper
         title="선택 유저 통계량 확인"
-        type="dropdown"
+        type="block"
         options={{
           labels: ["영역별 그래프", "유저별 그래프", "테이블 보기"],
           datasets: {


### PR DESCRIPTION
## 📌 PR 개요

관리자 활동 대시보드 제작

## 🛠 작업 내용

- [x] 활동 제출 요약
3Q별 제출 비율과 이번달, 변화량, 전체 제출에 대한 통계 제공
- [x] 영역별 제출 현황 그래프
각 영역별 제출양 그래프 제공

## 🖼 스크린샷 (선택)
- 요약 정보
![스크린샷 2025-05-07 오후 9 27 55](https://github.com/user-attachments/assets/8f55d31c-74cc-4161-bd4d-64917ec022a2)

- 교류지표는 카테고리가 많아 드롭다운으로 제작
![스크린샷 2025-05-07 오후 9 28 16](https://github.com/user-attachments/assets/bff191d2-0eb9-4153-aba4-9f0a049ffedb)

## 기타
아직 필터링 같은 데이터 로직은 추가하지 않았습니다. 우선 디자인 프로토타입이 완성되면 백엔드와 연결하면서 같이 작업하겠습니다.

## 🔗 연관된 이슈

- closes #20 
