### PR TITLE
Feature/#22 student dashboard

### DIFF
--- a/src/components/graphs/LineChart.tsx
+++ b/src/components/graphs/LineChart.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import {
+  LineChart as RechartsLineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { css } from "@emotion/react";
+
+interface DataPoint {
+  year: number;
+  LQ: number;
+  CQ: number;
+  RQ: number;
+}
+
+interface LineChartProps {
+  data: DataPoint[];
+}
+
+const chartContainer = css`
+  width: 100%;
+  height: 400px;
+  padding: 20px;
+`;
+
+const LineChart: React.FC<LineChartProps> = ({ data }) => {
+  return (
+    <div css={chartContainer}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsLineChart
+          data={data}
+          margin={{
+            top: 5,
+            right: 30,
+            left: 20,
+            bottom: 5,
+          }}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="year" label={{ value: "연도", position: "bottom" }} />
+          <YAxis
+            label={{ value: "점수", angle: -90, position: "insideLeft" }}
+          />
+          <Tooltip />
+          <Legend />
+          <Line
+            type="monotone"
+            dataKey="LQ"
+            stroke="#0088FE"
+            name="LQ"
+            strokeWidth={2}
+          />
+          <Line
+            type="monotone"
+            dataKey="CQ"
+            stroke="#FFBB28"
+            name="CQ"
+            strokeWidth={2}
+          />
+          <Line
+            type="monotone"
+            dataKey="RQ"
+            stroke="#00C49F"
+            name="RQ"
+            strokeWidth={2}
+          />
+        </RechartsLineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default LineChart;

--- a/src/pages/student/activity/index.tsx
+++ b/src/pages/student/activity/index.tsx
@@ -1,14 +1,408 @@
-import React from "react";
+import React, { useState } from "react";
+import ActivityListItem from "../../admin/activiy/list/components/ActivityListItem";
 import { css } from "@emotion/react";
+import Card from "@/styles/components/Card";
+import FlexBox from "@/styles/components/Flexbox";
+import Modal from "@/components/overlays/Modal";
+import SideOver from "@/components/overlays/SideOver";
+import ActivityFilter from "../../admin/activiy/list/components/ActivityFilter";
+import styled from "@emotion/styled";
+
+const titleStyle = css`
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 0;
+`;
+
+const subtitleStyle = css`
+  font-size: 1.8rem;
+`;
+
+const descriptionStyle = css`
+  font-size: 1.5rem;
+  color: #777;
+  margin-top: 0;
+`;
+
+const filterButtonStyle = css`
+  padding: 8px 16px;
+  background-color: #f5f5f5;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &:hover {
+    background-color: #e8e8e8;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  }
+`;
+
+const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: #e5e7eb;
+  margin: 0;
+`;
+
+// 더미 데이터
+const data = [
+  {
+    activity_id: 1,
+    category: "RQ" as const,
+    activity_class: "학술지 논문게재",
+    activity_detail: "(인문사회계) KCI 등재",
+    title: "인공지능을 활용한 학습 효율성 연구",
+    status: "승인" as const,
+    date: "2023-10-15",
+    user: {
+      name: "김철수",
+      department: "소프트웨어학과",
+      student_id: "20201234",
+    },
+  },
+  {
+    activity_id: 2,
+    category: "LQ" as const,
+    activity_class: "교육활동",
+    activity_detail:
+      "교내외의 교육 활동(초/중/고/대멘토링, 동료 티칭 등 학과장 승인건)",
+    title: "블록체인 기술 세미나 참여",
+    status: "대기" as const,
+    date: "2023-10-20",
+    user: {
+      name: "이영희",
+      department: "컴퓨터공학과",
+      student_id: "20195678",
+    },
+  },
+  {
+    activity_id: 3,
+    category: "CQ" as const,
+    activity_class: "학생회",
+    activity_detail: "임원진",
+    title: "학과 홍보 영상 제작 프로젝트",
+    status: "반려" as const,
+    date: "2023-09-28",
+    user: {
+      name: "박지민",
+      department: "미디어학과",
+      student_id: "20187777",
+    },
+  },
+  {
+    activity_id: 4,
+    category: "RQ" as const,
+    activity_class: "공모전/ICPC",
+    activity_detail: "(과학기술계) 대상/입상, 참여",
+    title: "사용자 경험 개선을 위한 UI/UX 실험",
+    status: "승인" as const,
+    date: "2023-10-05",
+    user: {
+      name: "정민준",
+      department: "디자인학과",
+      student_id: "20212345",
+    },
+  },
+  {
+    activity_id: 5,
+    category: "LQ" as const,
+    activity_class: "교육 성취도",
+    activity_detail: "학점 4.0 이상 ~ 4.5 이하",
+    title: "데이터 분석 워크숍 참가",
+    status: "대기" as const,
+    date: "2023-10-22",
+    user: {
+      name: "최수진",
+      department: "통계학과",
+      student_id: "20203333",
+    },
+  },
+  {
+    activity_id: 6,
+    category: "CQ" as const,
+    activity_class: "알리미",
+    activity_detail: "참여",
+    title: "신입생 멘토링 프로그램 진행",
+    status: "승인" as const,
+    date: "2023-09-15",
+    user: {
+      name: "강동원",
+      department: "소프트웨어학과",
+      student_id: "20184444",
+    },
+  },
+  {
+    activity_id: 7,
+    category: "RQ" as const,
+    activity_class: "학술대회 발표",
+    activity_detail: "(과학기술계) 학술대회 구두발표",
+    title: "IoT 기반 스마트홈 시스템 개발",
+    status: "대기" as const,
+    date: "2023-10-18",
+    user: {
+      name: "송지은",
+      department: "전자공학과",
+      student_id: "20205555",
+    },
+  },
+  {
+    activity_id: 8,
+    category: "LQ" as const,
+    activity_class: "오픈소스 SW활동",
+    activity_detail: "커미터로서의 활동(5/4/3) - 운영위 심사",
+    title: "클라우드 컴퓨팅 특강 수강",
+    status: "승인" as const,
+    date: "2023-10-10",
+    user: {
+      name: "황민석",
+      department: "컴퓨터공학과",
+      student_id: "20196666",
+    },
+  },
+  {
+    activity_id: 9,
+    category: "CQ" as const,
+    activity_class: "화상강연/세미나 참여",
+    activity_detail: "참여",
+    title: "학술대회 연구 결과 발표",
+    status: "반려" as const,
+    date: "2023-09-30",
+    user: {
+      name: "임서연",
+      department: "정보통신학과",
+      student_id: "20208888",
+    },
+  },
+  {
+    activity_id: 10,
+    category: "RQ" as const,
+    activity_class: "학술지 논문게재",
+    activity_detail: "(과학기술계) JCR 상위 20% 이내 학술지(주저/공저)",
+    title: "머신러닝 알고리즘 비교 연구",
+    status: "대기" as const,
+    date: "2023-10-25",
+    user: {
+      name: "오준호",
+      department: "인공지능학과",
+      student_id: "20219999",
+    },
+  },
+  {
+    activity_id: 11,
+    category: "LQ" as const,
+    activity_class: "교육활동",
+    activity_detail: "교육조교 활동(학부생 TA)",
+    title: "인공지능 윤리에 관한 도서 리뷰",
+    status: "승인" as const,
+    date: "2023-11-02",
+    user: {
+      name: "김민지",
+      department: "철학과",
+      student_id: "20211122",
+    },
+  },
+  {
+    activity_id: 12,
+    category: "CQ" as const,
+    activity_class: "해외봉사",
+    activity_detail: "수행",
+    title: "지역 아동센터 코딩 교육 봉사",
+    status: "승인" as const,
+    date: "2023-10-30",
+    user: {
+      name: "이준영",
+      department: "교육학과",
+      student_id: "20193344",
+    },
+  },
+  {
+    activity_id: 13,
+    category: "RQ" as const,
+    activity_class: "공모전/ICPC",
+    activity_detail: "(인문사회계) 국제/대규모 공모전(ICPC, 공개SW개발자대회)",
+    title: "블록체인 기반 학생증 시스템 특허 출원",
+    status: "대기" as const,
+    date: "2023-11-05",
+    user: {
+      name: "박서현",
+      department: "정보보호학과",
+      student_id: "20185566",
+    },
+  },
+  {
+    activity_id: 14,
+    category: "LQ" as const,
+    activity_class: "교육 성취도",
+    activity_detail: "학점 3.5 이상 ~ 4.0 미만",
+    title: "정보처리기사 자격증 취득",
+    status: "승인" as const,
+    date: "2023-10-28",
+    user: {
+      name: "정다은",
+      department: "소프트웨어학과",
+      student_id: "20207788",
+    },
+  },
+  {
+    activity_id: 15,
+    category: "CQ" as const,
+    activity_class: "스터디그룹",
+    activity_detail: "회장",
+    title: "프로그래밍 동아리 알고리즘 대회 개최",
+    status: "반려" as const,
+    date: "2023-11-01",
+    user: {
+      name: "한지훈",
+      department: "컴퓨터공학과",
+      student_id: "20182233",
+    },
+  },
+  {
+    activity_id: 16,
+    category: "RQ" as const,
+    activity_class: "학술지 논문게재",
+    activity_detail: "(인문사회계) KCI 우수등재 학술지",
+    title: "빅데이터 분석을 통한 소비자 행동 연구",
+    status: "승인" as const,
+    date: "2023-10-12",
+    user: {
+      name: "최윤서",
+      department: "경영학과",
+      student_id: "20204455",
+    },
+  },
+  {
+    activity_id: 17,
+    category: "LQ" as const,
+    activity_class: "오픈소스 SW활동",
+    activity_detail: "OS커뮤니티 생성 및 활성도(5/4/3) - 운영위 심사",
+    title: "AWS 클라우드 자격증 온라인 강의 수강",
+    status: "대기" as const,
+    date: "2023-11-08",
+    user: {
+      name: "김태호",
+      department: "클라우드컴퓨팅학과",
+      student_id: "20216677",
+    },
+  },
+  {
+    activity_id: 18,
+    category: "CQ" as const,
+    activity_class: "학생회",
+    activity_detail: "회장",
+    title: "학과 MT 기획 및 진행",
+    status: "승인" as const,
+    date: "2023-09-20",
+    user: {
+      name: "이수빈",
+      department: "소프트웨어학과",
+      student_id: "20198899",
+    },
+  },
+  {
+    activity_id: 19,
+    category: "RQ" as const,
+    activity_class: "공모전/ICPC",
+    activity_detail: "(과학기술계) 대상/입상, 참여",
+    title: "전국 대학생 소프트웨어 경진대회 참가",
+    status: "대기" as const,
+    date: "2023-11-10",
+    user: {
+      name: "장민호",
+      department: "인공지능학과",
+      student_id: "20202211",
+    },
+  },
+  {
+    activity_id: 20,
+    category: "LQ" as const,
+    activity_class: "교육활동",
+    activity_detail:
+      "교내외의 교육 활동(초/중/고/대멘토링, 동료 티칭 등 학과장 승인건)",
+    title: "알고리즘 스터디 그룹 운영",
+    status: "승인" as const,
+    date: "2023-10-08",
+    user: {
+      name: "신예진",
+      department: "컴퓨터공학과",
+      student_id: "20214433",
+    },
+  },
+] as const;
 
 const StudentActivityList: React.FC = () => {
+  // zustand로 다 빼버릴지 고민중
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedActivityId, setSelectedActivityId] = useState<number | null>(
+    null
+  );
+  const [isSideOverOpen, setIsSideOverOpen] = useState(false);
+
+  const handleDetailClick = (activity_id: number) => {
+    setSelectedActivityId(activity_id);
+    setIsModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedActivityId(null);
+  };
+
   return (
-    <div
-      css={css`
-        padding: 20px;
-      `}
-    >
-      <h1>Student Activity List</h1>
+    <div>
+      <h1 css={titleStyle}>활동 모아보기</h1>
+      <h2 css={descriptionStyle}>
+        활동 제출 후 검토 중인 활동을 확인할 수 있습니다.
+      </h2>
+      <FlexBox justify="space-between">
+        <h2 css={subtitleStyle}>활동 내역</h2>
+        <button css={filterButtonStyle} onClick={() => setIsSideOverOpen(true)}>
+          새로운 활동 제출
+        </button>
+      </FlexBox>
+
+      {/* TODO: 스크롤 넣올지 말지 의논 */}
+      <Card>
+        <FlexBox direction="column" gap="12px">
+          {data.map((item) => (
+            <React.Fragment key={item.activity_id}>
+              <ActivityListItem {...item} onDetailClick={handleDetailClick} />
+              <Divider />
+            </React.Fragment>
+          ))}
+        </FlexBox>
+      </Card>
+
+      {/* 필터링 사이드바 */}
+      <SideOver
+        title="활동 필터링"
+        isOpen={isSideOverOpen}
+        onClose={() => {
+          setIsSideOverOpen(false);
+        }}
+      >
+        <ActivityFilter />
+      </SideOver>
+      {/* 활동 상세보기 모달 */}
+      {/* <Modal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+        title="활동 상세 보기"
+      >
+        {selectedActivityId && (
+          <ActivityDetail
+            activity_id={selectedActivityId}
+            view_type="history"
+          />
+        )}
+      </Modal> */}
     </div>
   );
 };

--- a/src/pages/student/dashboard/components/ActivityPreviwItem.tsx
+++ b/src/pages/student/dashboard/components/ActivityPreviwItem.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+const categoryColor = {
+  LQ: "#0088FE",
+  RQ: "#00C49F",
+  CQ: "#FFBB28",
+};
+
+interface ActivityPreviewItemProps {
+  title: string;
+  category: "LQ" | "RQ" | "CQ";
+  status: "승인" | "반려" | "대기";
+  date?: string;
+}
+
+const cardStyle = css`
+  display: flex;
+  align-items: center;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  padding: 18px 20px;
+  margin-bottom: 12px;
+  min-width: 320px;
+  justify-content: space-between;
+`;
+
+const dotStyle = (color: string) => css`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: ${color};
+  margin-right: 14px;
+`;
+
+const titleStyle = css`
+  font-size: 1.1rem;
+  font-weight: 500;
+`;
+
+const statusStyle = (status: string) => {
+  let color = "#888";
+  if (status === "승인") color = "#2ecc40"; // 초록
+  else if (status === "대기") color = "#ffcc00"; // 노랑
+  else if (status === "반려") color = "#ff4d4f"; // 빨강
+  return css`
+    font-size: 1.1rem;
+    font-weight: bold;
+    color: ${color};
+  `;
+};
+
+const ActivityPreviewItem: React.FC<ActivityPreviewItemProps> = ({
+  title,
+  category,
+  status,
+  date,
+}) => (
+  <div css={cardStyle}>
+    <div style={{ display: "flex", alignItems: "center" }}>
+      <div css={dotStyle(categoryColor[category])} />
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <span css={titleStyle}>{title}</span>
+        {date && (
+          <span style={{ color: "#888", fontSize: "0.95rem", marginTop: 2 }}>
+            {date}
+          </span>
+        )}
+      </div>
+    </div>
+    <span css={statusStyle(status)}>{status}</span>
+  </div>
+);
+
+export default ActivityPreviewItem;

--- a/src/pages/student/dashboard/components/QCardVertical.tsx
+++ b/src/pages/student/dashboard/components/QCardVertical.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { css } from "@emotion/react";
+
+interface QCardVerticalProps {
+  title: string;
+  category: "LQ" | "RQ" | "CQ";
+  description: string;
+  score: number;
+  percentage: number;
+  total: number;
+}
+
+const cardStyle = css`
+  border-radius: 12px;
+  padding: 12px;
+  max-width: 540px;
+`;
+
+const topSection = css`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+`;
+
+const leftInfo = css`
+  display: flex;
+  align-items: flex-start;
+`;
+
+const dotStyle = (category: string) => css`
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: ${category === "LQ"
+    ? "#0088FE"
+    : category === "RQ"
+    ? "#00C49F"
+    : "#FFBB28"};
+  margin-right: 16px;
+  margin-top: 6px;
+`;
+
+const textInfo = css`
+  display: flex;
+  flex-direction: column;
+`;
+
+const titleStyle = css`
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 2px;
+`;
+
+const descriptionStyle = css`
+  color: #757575;
+  font-size: 1rem;
+  margin-bottom: 0;
+`;
+
+const scoreStyle = css`
+  font-size: 1.6rem;
+  font-weight: 800;
+  margin-left: 24px;
+  margin-top: 2px;
+`;
+
+const barSection = css`
+  display: flex;
+  align-items: center;
+  margin-top: 24px;
+`;
+
+const barContainerStyle = css`
+  flex: 1;
+  height: 8px;
+  background: #f3f3f3;
+  border-radius: 6px;
+  margin-right: 16px;
+`;
+
+const barStyle = (percent: number) => css`
+  height: 100%;
+  width: ${percent}%;
+  background: #222;
+  border-radius: 6px;
+  transition: width 0.4s;
+`;
+
+const percentTextStyle = css`
+  color: #757575;
+  font-size: 1rem;
+  font-weight: 500;
+  min-width: 70px;
+`;
+
+const bottomSection = css`
+  margin-top: 24px;
+  color: #757575;
+  font-size: 1rem;
+  font-weight: 500;
+`;
+
+const QCardVertical: React.FC<QCardVerticalProps> = ({
+  title,
+  category,
+  description,
+  score,
+  percentage,
+  total,
+}) => {
+  return (
+    <div css={cardStyle}>
+      <div css={topSection}>
+        <div css={leftInfo}>
+          <div css={dotStyle(category)} />
+          <div css={textInfo}>
+            <span css={titleStyle}>{title}</span>
+            <span css={descriptionStyle}>{description}</span>
+          </div>
+        </div>
+        <div css={scoreStyle}>{score}점</div>
+      </div>
+      <div css={barSection}>
+        <div css={barContainerStyle}>
+          <div css={barStyle((score / total) * 100)} />
+        </div>
+        <span css={percentTextStyle}>상위 {percentage}%</span>
+      </div>
+      <div css={bottomSection}>학과 평균: {total}점</div>
+    </div>
+  );
+};
+
+export default QCardVertical;

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -5,6 +5,7 @@ import GraphWrapper from "@/components/graphs/GraphWrapper";
 import LineChart from "@/components/graphs/LineChart";
 import StackedBarChart from "@/components/graphs/StackedBarChart";
 import QuotientChart from "@/components/graphs/QuotientChart";
+import ActivityPreviewItem from "./components/ActivityPreviwItem";
 
 const titleStyle = css`
   font-size: 2.5rem;
@@ -23,6 +24,22 @@ const summaryContainerStyle = css`
   flex-direction: row;
   gap: 30px;
   justify-content: space-between;
+`;
+
+const viewAllButtonStyle = css`
+  width: 100%;
+  padding: 12px;
+  background-color: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: center;
+  transition: background-color 0.2s;
+  &:hover {
+    background-color: #f9f9f9;
+  }
 `;
 
 const QData = [
@@ -78,6 +95,40 @@ const totalData = {
   ],
 };
 
+const activityPreviewData = [
+  {
+    title: "빅데이터 분석을 통한 소비자 행동 연구",
+    category: "LQ" as "LQ" | "RQ" | "CQ",
+    status: "승인" as "승인" | "반려" | "대기",
+    date: "2024-01-01",
+  },
+
+  {
+    title: "학과 MT 기획 및 진행",
+    category: "CQ" as "LQ" | "RQ" | "CQ",
+    status: "대기" as "승인" | "반려" | "대기",
+    date: "2024-01-01",
+  },
+  {
+    title: "전국 대학생 소프트웨어 경진대회 참가",
+    category: "RQ" as "LQ" | "RQ" | "CQ",
+    status: "승인" as "승인" | "반려" | "대기",
+    date: "2024-01-01",
+  },
+  {
+    title: "ICPC 금상",
+    category: "LQ" as "LQ" | "RQ" | "CQ",
+    status: "반려" as "승인" | "반려" | "대기",
+    date: "2024-01-01",
+  },
+  {
+    title: "알고리즘 스터디 그룹 운영",
+    category: "LQ" as "LQ" | "RQ" | "CQ",
+    status: "승인" as "승인" | "반려" | "대기",
+    date: "2024-01-01",
+  },
+];
+
 const StudentDashboard: React.FC = () => {
   return (
     <div>
@@ -101,6 +152,30 @@ const StudentDashboard: React.FC = () => {
         {/* 최근 활동 내역 */}
         <div css={{ width: "100%" }}>
           <h2 css={subtitleStyle}>최근 활동 내역</h2>
+          {activityPreviewData.map((activity) => (
+            <ActivityPreviewItem
+              title={activity.title}
+              category={activity.category}
+              status={activity.status}
+              date={activity.date}
+            />
+          ))}
+          <div
+            css={css`
+              margin-top: 16px;
+              width: 100%;
+            `}
+          >
+            <button
+              css={viewAllButtonStyle}
+              onClick={() => {
+                // 전체 활동 내역 페이지로 이동하는 로직
+                // window.location.href = "/student/activity/view";
+              }}
+            >
+              전체 활동 내역 보기
+            </button>
+          </div>
         </div>
       </div>
       <GraphWrapper

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -1,14 +1,120 @@
 import React from "react";
 import { css } from "@emotion/react";
+import QCardVertical from "./components/QCardVertical";
+import GraphWrapper from "@/components/graphs/GraphWrapper";
+import LineChart from "@/components/graphs/LineChart";
+import StackedBarChart from "@/components/graphs/StackedBarChart";
+import QuotientChart from "@/components/graphs/QuotientChart";
+
+const titleStyle = css`
+  font-size: 2.5rem;
+  font-weight: bold;
+  margin-bottom: 0;
+`;
+
+const subtitleStyle = css`
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 0;
+`;
+
+const summaryContainerStyle = css`
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  justify-content: space-between;
+`;
+
+const QData = [
+  {
+    title: "Learning Quotient (LQ)",
+    category: "LQ" as "LQ" | "RQ" | "CQ",
+    description: "학습 능력 지수",
+    score: 23,
+    total: 33,
+    percentage: 12,
+  },
+  {
+    title: "Research Quotient (RQ)",
+    category: "RQ" as "LQ" | "RQ" | "CQ",
+    description: "연구 능력 지수",
+    score: 28,
+    total: 33,
+    percentage: 5,
+  },
+  {
+    title: "Creative Quotient (CQ)",
+    category: "CQ" as "LQ" | "RQ" | "CQ",
+    description: "교류 능력 지수",
+    score: 19,
+    total: 33,
+    percentage: 28,
+  },
+];
+
+const lineChartData = [
+  { year: 2019, LQ: 15, CQ: 12, RQ: 18 },
+  { year: 2020, LQ: 18, CQ: 15, RQ: 20 },
+  { year: 2021, LQ: 22, CQ: 19, RQ: 25 },
+  { year: 2022, LQ: 25, CQ: 23, RQ: 28 },
+  { year: 2023, LQ: 28, CQ: 26, RQ: 31 },
+];
+
+const totalData = {
+  RQ: [
+    { name: "내 점수", score: 28 },
+    { name: "학과 평균", score: 25 },
+    { name: "전체 평균", score: 27 },
+  ],
+  LQ: [
+    { name: "내 점수", score: 30 },
+    { name: "학과 평균", score: 29 },
+    { name: "전체 평균", score: 31 },
+  ],
+  CQ: [
+    { name: "내 점수", score: 22 },
+    { name: "학과 평균", score: 19 },
+    { name: "전체 평균", score: 23 },
+  ],
+};
 
 const StudentDashboard: React.FC = () => {
   return (
-    <div
-      css={css`
-        padding: 20px;
-      `}
-    >
-      <h1>Student Dashboard</h1>
+    <div>
+      <h1 css={titleStyle}>Student Dashboard</h1>
+      <div css={summaryContainerStyle}>
+        {/* 3Q 통계 */}
+
+        <div css={{ width: "100%" }}>
+          <h2 css={subtitleStyle}>3Q 지표 요약</h2>
+          {QData.map((q) => (
+            <QCardVertical
+              title={q.title}
+              category={q.category}
+              description={q.description}
+              score={q.score}
+              total={q.total}
+              percentage={q.percentage}
+            />
+          ))}
+        </div>
+        {/* 최근 활동 내역 */}
+        <div css={{ width: "100%" }}>
+          <h2 css={subtitleStyle}>최근 활동 내역</h2>
+        </div>
+      </div>
+      <GraphWrapper
+        title="성과 분석"
+        type="block"
+        options={{
+          labels: ["연도별 변화 추이", "지수별 분석", "학과별 비교"],
+          datasets: {
+            "연도별 변화 추이": <LineChart data={lineChartData} />,
+            "지수별 분석": <QuotientChart data={totalData} />,
+            "학과별 비교": <StackedBarChart data={totalData} />,
+          },
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## 📌 PR 개요

학생 로그인 시 보이는 대시보드 페이지 제작

## 🛠 작업 내용

- [x] 학생 대시보드
- 현재 본인의 3Q 점수, 학과 평균 등을 볼 수 있게 제작
- 최근 활동 내역을 한 눈에 볼 수 있게 제작
- 연도별 점수 추이, 학과 평균과의 비교 등의 그래프 추가
- [x] 학생 활동 모아보기
우선 이 페이지는 관리자의 페이지와 비슷하게 갈 것 같아서 일단 관리자 페이지 그대로 복붙만 해놨습니다.
아마 디자인은 바뀔 것 같은데 일단 배포하기 전에 페이지가 비어있으면 좀 그래서 넣어뒀고, 추후 다시 수정할 예정입니다.

## 🖼 스크린샷 (선택)
<img width="1792" alt="스크린샷 2025-05-15 오전 12 21 38" src="https://github.com/user-attachments/assets/3347e519-6e5a-464f-ac67-f6d8e58655ed" />

## 기타
지금 디자인이 원래와 살짝 느낌이 다른데 아마 최근에 추가한 디자인을 메인으로 가져갈 것 같습니다(하다보니 이게 더 이뻐보여서...)
디자인이 대충 확정됐으니, 디자인 관련 요소도 전역으로 뺼 수 있으면 빼고 원래 만들어두었던 디자인도 조금씩 수정할 예정입니다.

- 최근 디자인 느낌
<img width="500" alt="스크린샷 2025-05-15 오전 12 23 50" src="https://github.com/user-attachments/assets/95025e5f-119a-494e-8a0a-eb58f21f2412" />
<img width="500" alt="스크린샷 2025-05-15 오전 12 23 38" src="https://github.com/user-attachments/assets/be333723-deab-4f27-a6de-23a7b3dff57e" />

RQ, LQ, CQ 마다 고유의 색을 부여해서 그 색 팔레트 위주로 진행할 예정
- 예전 느낌
<img width="500" alt="스크린샷 2025-05-15 오전 12 25 47" src="https://github.com/user-attachments/assets/23addaac-61a2-4b13-928b-1ef411939fba" />
<img width="500" alt="스크린샷 2025-05-15 오전 12 25 41" src="https://github.com/user-attachments/assets/4998c9ad-7ca8-408a-8529-c45b483cc5d2" />

좀 딱딱한 느낌에다가 색상 팔레트도 뭘 써야할 지 애매해서 아마 변경할듯요..?
혹시 디자인 관련 의견 주시면 반영하겠습니다

## 🔗 연관된 이슈
- closes #22 
