### PR TITLE
chore: 라우팅 이름 변경

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -13,8 +13,6 @@ import StudentActivitySubmit from "@/pages/student/activity/submit";
 import StudentActivityView from "@/pages/student/activity/view";
 
 // admin
-import AdminActivityView from "@/pages/admin/activiy/list/view";
-import AdminActivityReview from "@/pages/admin/activiy/list/review";
 import AdminActivityList from "@/pages/admin/activiy/list";
 import AdminActivityDashboard from "@/pages/admin/activiy/dashboard";
 import AdminStatisticDashboard from "@/pages/admin/statistic/dashboard";
@@ -72,7 +70,7 @@ const Router = createBrowserRouter([
 
   // Admin routes
   {
-    path: "/admin",
+    path: "/manager",
     element: <ProtectedRoute allowedRoles={["admin"]} />,
     children: [
       {
@@ -80,7 +78,7 @@ const Router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <Navigate to="/admin/statistic/dashboard" />,
+            element: <Navigate to="/manager/statistic/dashboard" />,
           },
           {
             path: "statistic",
@@ -106,7 +104,7 @@ const Router = createBrowserRouter([
 
   // Super Admin routes
   {
-    path: "/superAdmin",
+    path: "/superManager",
     element: <ProtectedRoute allowedRoles={["super-admin"]} />,
     children: [
       {
@@ -114,7 +112,7 @@ const Router = createBrowserRouter([
         children: [
           {
             index: true,
-            element: <Navigate to="/superAdmin/statistic/dashboard" />,
+            element: <Navigate to="/superManager/statistic/dashboard" />,
           },
           {
             path: "statistic",

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -6,8 +6,8 @@ interface ProtectedRouteProps {
 
 const defaultPage: Record<string, string> = {
   student: "/student",
-  admin: "/admin",
-  "super-admin": "/superAdmin",
+  admin: "/manager",
+  "super-admin": "/superManager",
 };
 
 const ProtectedRoute = ({ allowedRoles }: ProtectedRouteProps) => {

--- a/src/components/layouts/NavBar.tsx
+++ b/src/components/layouts/NavBar.tsx
@@ -60,24 +60,24 @@ const adminRouteMap = {
   // 관리자 라우트
   admin: [
     [
-      { path: "/admin/statistic/dashboard", label: "대시보드" },
-      { path: "/admin/statistic/individual", label: "개인별 통계" },
+      { path: "/manager/statistic/dashboard", label: "대시보드" },
+      { path: "/manager/statistic/individual", label: "개인별 통계" },
     ],
     [
-      { path: "/admin/activity/dashboard", label: "대시보드" },
-      { path: "/admin/activity/list", label: "활동 목록" },
+      { path: "/manager/activity/dashboard", label: "대시보드" },
+      { path: "/manager/activity/list", label: "활동 목록" },
     ],
   ],
   // 슈퍼 관리자 라우트
   "super-admin": [
     [
-      { path: "/superAdmin/statistic/dashboard", label: "대시보드" },
-      { path: "/superAdmin/statistic/individual", label: "개인별 통계" },
-      { path: "/superAdmin/statistic/parameter", label: "파라미터 설정" },
+      { path: "/superManager/statistic/dashboard", label: "대시보드" },
+      { path: "/superManager/statistic/individual", label: "개인별 통계" },
+      { path: "/superManager/statistic/parameter", label: "파라미터 설정" },
     ],
     [
-      { path: "/superAdmin/activity/dashboard", label: "대시보드" },
-      { path: "/superAdmin/activity/list", label: "활동 목록" },
+      { path: "/superManager/activity/dashboard", label: "대시보드" },
+      { path: "/superManager/activity/list", label: "활동 목록" },
     ],
   ],
 };
@@ -91,7 +91,7 @@ const NavBar: React.FC = () => {
   const handleToggle = () => {
     toggleTab();
     const basePath =
-      userProfile?.role === "super-admin" ? "/superAdmin" : "/admin";
+      userProfile?.role === "super-admin" ? "/superManager" : "/manager";
     navigate(
       selectedTab === "statistic"
         ? `${basePath}/activity/dashboard`


### PR DESCRIPTION
## 📌 PR 개요

학교 서버 차단을 피하기 위한 라우팅 이름 변경

## 🛠 작업 내용

학교 서버에서 admin이 포함된 경로는 자동으로 차단되게 때문에 manager로 일괄 변경 진행했습니다.

## 🖼 스크린샷 (선택)

## 🔗 연관된 이슈

- closes #이슈번호
