### PR TITLE
점수내역, 제출방식, 댓글 관련

### DIFF
--- a/src/apis/admin/deleteSubmitComment.ts
+++ b/src/apis/admin/deleteSubmitComment.ts
@@ -1,0 +1,11 @@
+import axiosInstance from "@/apis/utils/axiosInterceptor";
+
+const deleteSubmitComment = async (commentId: number) => {
+  const response = await axiosInstance.delete(
+    `/admin/submit/comment/${commentId}`
+  );
+  return response.data;
+};
+
+export default deleteSubmitComment;
+

--- a/src/apis/admin/patchSubmitComment.ts
+++ b/src/apis/admin/patchSubmitComment.ts
@@ -1,0 +1,18 @@
+import axiosInstance from "@/apis/utils/axiosInterceptor";
+
+const patchSubmitComment = async ({
+  id,
+  content,
+}: {
+  id: number;
+  content: string;
+}) => {
+  const response = await axiosInstance.patch("/admin/submit/comment", {
+    id,
+    content,
+  });
+  return response.data;
+};
+
+export default patchSubmitComment;
+

--- a/src/components/activity/ActivityDetailModal.tsx
+++ b/src/components/activity/ActivityDetailModal.tsx
@@ -36,9 +36,11 @@ const ActivityDetailModal: React.FC<ActivityDetailModalProps> = ({ id, open, onC
           aria-label="close"
           onClick={onClose}
           sx={{
-            position: "absolute",
-            right: 8,
+            position: "sticky",
+            float: "right",
             top: 8,
+            right: 8,
+            marginBottom: "-40px",
             color: (theme) => theme.palette.grey[500],
           }}
         >

--- a/src/components/activity/StudentActivityMainContentView.tsx
+++ b/src/components/activity/StudentActivityMainContentView.tsx
@@ -1,10 +1,20 @@
+/** @jsxImportSource @emotion/react */
 import useStudentActivityItem from "@/hooks/student/useStudentActivityItem";
 import React, { useState, useRef } from "react";
+import ReactDOM from "react-dom";
 import Loading from "../layouts/Loading";
 import axiosInstance from "@/apis/utils/axiosInterceptor";
 import useDeleteStudentActivity from "@/hooks/student/useDeleteStudentActivity";
 import usePatchStudentActivity from "@/hooks/student/usePatchStudentActivity";
 import usePostStudentActivityAddFiles from "@/hooks/student/usePostStudentActivityAddFiles";
+import {
+  ModalOverlay,
+  ModalContent,
+  ModalTitle,
+  ModalDesc,
+  ModalButtonContainer,
+  ModalButton,
+} from "@/styles/components/Modal";
 const sectionStyle: React.CSSProperties = {
   marginBottom: 28,
 };
@@ -221,9 +231,10 @@ interface FileData {
 const StudentActivityMainContentView = ({ id }: { id: string }) => {
   const { data, isLoading } = useStudentActivityItem(id);
   const [files, setFiles] = useState<FileData[]>([]);
-  const [showConfirm, setShowConfirm] = useState<boolean>(false);
+  const [showSaveConfirm, setShowSaveConfirm] = useState<boolean>(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<boolean>(false);
   const [showFileConfirm, setShowFileConfirm] = useState<boolean>(false);
+  const [showApprovedWarning, setShowApprovedWarning] = useState<boolean>(false);
   const [isEditMode, setIsEditMode] = useState<boolean>(false);
   const [editTitle, setEditTitle] = useState<string>("");
   const [editContent, setEditContent] = useState<string>("");
@@ -237,9 +248,19 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
 
   // 수정 모드 진입
   const handleEditClick = () => {
+    // 승인된 제출내역(state=1)은 수정할 수 없음
+    if (data.basicInfo.state === 1) {
+      setShowApprovedWarning(true);
+      return;
+    }
     setEditTitle(data.basicInfo.title);
     setEditContent(data.basicInfo.content);
     setIsEditMode(true);
+  };
+
+  // 승인 경고 모달 닫기
+  const handleCloseApprovedWarning = () => {
+    setShowApprovedWarning(false);
   };
 
   // 수정 취소
@@ -252,6 +273,11 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
 
   // 삭제 확인
   const handleDeleteClick = () => {
+    // 승인된 제출내역(state=1)은 삭제할 수 없음
+    if (data.basicInfo.state === 1) {
+      setShowApprovedWarning(true);
+      return;
+    }
     setShowDeleteConfirm(true);
   };
 
@@ -281,7 +307,13 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
     setFiles((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const handleConfirmSubmit = () => {
+  // 저장 버튼 클릭 시 확인 모달 표시
+  const handleSaveClick = () => {
+    setShowSaveConfirm(true);
+  };
+
+  // 저장 확정
+  const handleConfirmSave = () => {
     // 제목과 내용 수정
     patchActivity(
       {
@@ -291,17 +323,22 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
       },
       {
         onSuccess: () => {
+          setShowSaveConfirm(false);
           // 파일이 있으면 파일 추가 확인
           if (files.length > 0) {
             setShowFileConfirm(true);
           } else {
             // 파일이 없으면 수정 완료
             setIsEditMode(false);
-            setShowConfirm(false);
           }
         },
       }
     );
+  };
+
+  // 저장 취소
+  const handleCancelSave = () => {
+    setShowSaveConfirm(false);
   };
 
   // 파일 추가 확정
@@ -314,7 +351,6 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
       {
         onSuccess: () => {
           setIsEditMode(false);
-          setShowConfirm(false);
           setShowFileConfirm(false);
           setFiles([]);
         },
@@ -326,12 +362,7 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
   const handleCancelAddFiles = () => {
     setShowFileConfirm(false);
     setIsEditMode(false);
-    setShowConfirm(false);
     setFiles([]);
-  };
-
-  const handleCancelSubmit = () => {
-    setShowConfirm(false);
   };
 
   return (
@@ -603,204 +634,108 @@ const StudentActivityMainContentView = ({ id }: { id: string }) => {
             </button>
           </div>
         ) : (
-          !showConfirm ? (
-            <div style={confirmBtnContainerStyle}>
-              <button
-                type="button"
-                style={confirmSubmitStyle}
-                onClick={() => setShowConfirm(true)}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#1a1a1a";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#2c2c2c";
-                }}
-              >
-                저장
-              </button>
-              <button
-                type="button"
-                style={confirmCancelStyle}
-                onClick={handleCancelEdit}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#e8e8e8";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#f5f5f5";
-                }}
-              >
-                취소
-              </button>
-            </div>
-          ) : (
-            <div style={confirmBtnContainerStyle}>
-              <button
-                type="button"
-                style={confirmSubmitStyle}
-                onClick={handleConfirmSubmit}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#1a1a1a";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#2c2c2c";
-                }}
-              >
-                확인
-              </button>
-              <button
-                type="button"
-                style={confirmCancelStyle}
-                onClick={handleCancelSubmit}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#e8e8e8";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#f5f5f5";
-                }}
-              >
-                취소
-              </button>
-            </div>
-          )
+          <div style={confirmBtnContainerStyle}>
+            <button
+              type="button"
+              style={confirmSubmitStyle}
+              onClick={handleSaveClick}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = "#1a1a1a";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = "#2c2c2c";
+              }}
+            >
+              저장
+            </button>
+            <button
+              type="button"
+              style={confirmCancelStyle}
+              onClick={handleCancelEdit}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.background = "#e8e8e8";
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.background = "#f5f5f5";
+              }}
+            >
+              취소
+            </button>
+          </div>
         )}
       </div>
 
-      {/* 삭제 확인 모달 */}
-      {showDeleteConfirm && (
-        <div style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: "rgba(0, 0, 0, 0.5)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          zIndex: 1000,
-        }}>
-          <div style={{
-            backgroundColor: "#fff",
-            borderRadius: 8,
-            padding: "24px 32px",
-            maxWidth: 400,
-            textAlign: "center",
-          }}>
-            <div style={{
-              fontSize: "1.125rem",
-              fontWeight: 600,
-              marginBottom: 16,
-            }}>
-              정말 삭제하시겠습니까?
-            </div>
-            <div style={{
-              fontSize: "0.875rem",
-              color: "#666",
-              marginBottom: 24,
-            }}>
-              삭제된 활동은 복구할 수 없습니다.
-            </div>
-            <div style={confirmBtnContainerStyle}>
-              <button
-                type="button"
-                style={{
-                  ...confirmBtnStyle,
-                  background: "#dc2626",
-                  color: "#fff",
-                }}
-                onClick={handleConfirmDelete}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#b91c1c";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#dc2626";
-                }}
-              >
-                삭제
-              </button>
-              <button
-                type="button"
-                style={confirmCancelStyle}
-                onClick={handleCancelDelete}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#e8e8e8";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#f5f5f5";
-                }}
-              >
+      {/* 저장 확인 모달 */}
+      {showSaveConfirm && ReactDOM.createPortal(
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>수정 사항을 저장하시겠습니까?</ModalTitle>
+            <ModalDesc>제목과 내용이 수정됩니다.</ModalDesc>
+            <ModalButtonContainer>
+              <ModalButton variant="primary" onClick={handleConfirmSave}>
+                저장
+              </ModalButton>
+              <ModalButton variant="cancel" onClick={handleCancelSave}>
                 취소
-              </button>
-            </div>
-          </div>
-        </div>
+              </ModalButton>
+            </ModalButtonContainer>
+          </ModalContent>
+        </ModalOverlay>,
+        document.body
+      )}
+
+      {/* 삭제 확인 모달 */}
+      {showDeleteConfirm && ReactDOM.createPortal(
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>정말 삭제하시겠습니까?</ModalTitle>
+            <ModalDesc>삭제된 활동은 복구할 수 없습니다.</ModalDesc>
+            <ModalButtonContainer>
+              <ModalButton variant="danger" onClick={handleConfirmDelete}>
+                삭제
+              </ModalButton>
+              <ModalButton variant="cancel" onClick={handleCancelDelete}>
+                취소
+              </ModalButton>
+            </ModalButtonContainer>
+          </ModalContent>
+        </ModalOverlay>,
+        document.body
       )}
 
       {/* 파일 추가 확인 모달 */}
-      {showFileConfirm && (
-        <div style={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: "rgba(0, 0, 0, 0.5)",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          zIndex: 1000,
-        }}>
-          <div style={{
-            backgroundColor: "#fff",
-            borderRadius: 8,
-            padding: "24px 32px",
-            maxWidth: 400,
-            textAlign: "center",
-          }}>
-            <div style={{
-              fontSize: "1.125rem",
-              fontWeight: 600,
-              marginBottom: 16,
-            }}>
-              파일을 추가하시겠습니까?
-            </div>
-            <div style={{
-              fontSize: "0.875rem",
-              color: "#666",
-              marginBottom: 24,
-            }}>
-              ⚠️ 기존 파일은 모두 삭제되고 새 파일로 교체됩니다.
-            </div>
-            <div style={confirmBtnContainerStyle}>
-              <button
-                type="button"
-                style={confirmSubmitStyle}
-                onClick={handleConfirmAddFiles}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#1a1a1a";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#2c2c2c";
-                }}
-              >
+      {showFileConfirm && ReactDOM.createPortal(
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>파일을 추가하시겠습니까?</ModalTitle>
+            <ModalDesc>⚠️ 기존 파일은 모두 삭제되고 새 파일로 교체됩니다.</ModalDesc>
+            <ModalButtonContainer>
+              <ModalButton variant="primary" onClick={handleConfirmAddFiles}>
                 추가
-              </button>
-              <button
-                type="button"
-                style={confirmCancelStyle}
-                onClick={handleCancelAddFiles}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.background = "#e8e8e8";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.background = "#f5f5f5";
-                }}
-              >
+              </ModalButton>
+              <ModalButton variant="cancel" onClick={handleCancelAddFiles}>
                 취소
-              </button>
-            </div>
-          </div>
-        </div>
+              </ModalButton>
+            </ModalButtonContainer>
+          </ModalContent>
+        </ModalOverlay>,
+        document.body
+      )}
+
+      {/* 승인된 제출내역 수정 불가 경고 모달 */}
+      {showApprovedWarning && ReactDOM.createPortal(
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>승인된 제출내역은 수정할 수 없습니다</ModalTitle>
+            <ModalDesc>이미 승인된 활동은 수정이 불가능합니다.</ModalDesc>
+            <ModalButtonContainer>
+              <ModalButton variant="primary" onClick={handleCloseApprovedWarning}>
+                확인
+              </ModalButton>
+            </ModalButtonContainer>
+          </ModalContent>
+        </ModalOverlay>,
+        document.body
       )}
     </div>
   );

--- a/src/components/activity/comments/CommentsList.tsx
+++ b/src/components/activity/comments/CommentsList.tsx
@@ -1,6 +1,19 @@
-import React from "react";
+/** @jsxImportSource @emotion/react */
+import React, { useState } from "react";
+import ReactDOM from "react-dom";
 import { css } from "@emotion/react";
 import type { ActivityComment } from "@/types/activitiy";
+import useAuthStore from "@/stores/auth/authStore";
+import usePatchSubmitComment from "@/hooks/admin/usePatchSubmitComment";
+import useDeleteSubmitComment from "@/hooks/admin/useDeleteSubmitComment";
+import {
+  ModalOverlay,
+  ModalContent,
+  ModalTitle,
+  ModalDesc,
+  ModalButtonContainer,
+  ModalButton,
+} from "@/styles/components/Modal";
 
 const listStyle = css`
   display: flex;
@@ -17,12 +30,89 @@ const itemStyle = css`
   border-radius: 0.5rem;
   color: #374151;
   font-size: 0.875rem;
+  position: relative;
 `;
 
 const dateStyle = css`
   font-size: 0.75rem;
   color: #6b7280;
   margin-top: 4px;
+`;
+
+const authorStyle = css`
+  font-size: 0.75rem;
+  color: #4b5563;
+  font-weight: 600;
+  margin-bottom: 4px;
+`;
+
+const buttonContainerStyle = css`
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+`;
+
+const buttonStyle = css`
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 500;
+  transition: all 0.2s;
+`;
+
+const editButtonStyle = css`
+  ${buttonStyle}
+  background-color: #dbeafe;
+  color: #1e40af;
+  &:hover {
+    background-color: #bfdbfe;
+  }
+`;
+
+const deleteButtonStyle = css`
+  ${buttonStyle}
+  background-color: #fee2e2;
+  color: #991b1b;
+  &:hover {
+    background-color: #fecaca;
+  }
+`;
+
+const saveButtonStyle = css`
+  ${buttonStyle}
+  background-color: #2c2c2c;
+  color: #fff;
+  &:hover {
+    background-color: #1a1a1a;
+  }
+`;
+
+const cancelButtonStyle = css`
+  ${buttonStyle}
+  background-color: #f5f5f5;
+  color: #666;
+  border: 1px solid #e0e0e0;
+  &:hover {
+    background-color: #e8e8e8;
+  }
+`;
+
+const textareaStyle = css`
+  width: 100%;
+  padding: 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 60px;
+  box-sizing: border-box;
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+  }
 `;
 
 interface CommentsListProps {
@@ -32,24 +122,164 @@ interface CommentsListProps {
 }
 
 const CommentsList: React.FC<CommentsListProps> = ({ comments = [], emptyText = "등록된 댓글이 없습니다.", maxHeight }) => {
+  const { userProfile } = useAuthStore();
+  const { mutate: patchComment } = usePatchSubmitComment();
+  const { mutate: deleteComment } = useDeleteSubmitComment();
+  
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editContent, setEditContent] = useState<string>("");
+  const [saveConfirmId, setSaveConfirmId] = useState<number | null>(null);
+  const [deleteConfirmId, setDeleteConfirmId] = useState<number | null>(null);
+
   const sorted = React.useMemo(
     () => [...comments].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
     [comments]
   );
 
+  const isAdmin = userProfile?.role === "admin" || userProfile?.role === "super-admin";
+  const currentUserId = userProfile?.id;
+
+  const handleEditClick = (comment: ActivityComment) => {
+    setEditingId(comment.id);
+    setEditContent(comment.content);
+  };
+
+  const handleSaveClick = (commentId: number) => {
+    setSaveConfirmId(commentId);
+  };
+
+  const handleConfirmSave = () => {
+    if (saveConfirmId) {
+      patchComment(
+        { id: saveConfirmId, content: editContent },
+        {
+          onSuccess: () => {
+            setEditingId(null);
+            setEditContent("");
+            setSaveConfirmId(null);
+          },
+        }
+      );
+    }
+  };
+
+  const handleCancelSave = () => {
+    setSaveConfirmId(null);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditContent("");
+  };
+
+  const handleDeleteClick = (commentId: number) => {
+    setDeleteConfirmId(commentId);
+  };
+
+  const handleConfirmDelete = () => {
+    if (deleteConfirmId) {
+      deleteComment(deleteConfirmId, {
+        onSuccess: () => {
+          setDeleteConfirmId(null);
+        },
+      });
+    }
+  };
+
+  const handleCancelDelete = () => {
+    setDeleteConfirmId(null);
+  };
+
+  const canModifyComment = (comment: ActivityComment) => {
+    return isAdmin && currentUserId === comment.userId;
+  };
+
   return (
-    <div css={[listStyle, maxHeight ? css`max-height: ${maxHeight}px;` : undefined]}>
-      {sorted.length > 0 ? (
-        sorted.map((c) => (
-          <div key={c.id} css={itemStyle}>
-            <div>{c.content}</div>
-            <div css={dateStyle}>{new Date(c.date).toLocaleString("ko-KR")}</div>
-          </div>
-        ))
-      ) : (
-        <div css={itemStyle}>{emptyText}</div>
+    <>
+      <div css={[listStyle, maxHeight ? css`max-height: ${maxHeight}px;` : undefined]}>
+        {sorted.length > 0 ? (
+          sorted.map((c) => (
+            <div key={c.id} css={itemStyle}>
+              <div css={authorStyle}>{c.userName}</div>
+              
+              {editingId === c.id ? (
+                <>
+                  <textarea
+                    css={textareaStyle}
+                    value={editContent}
+                    onChange={(e) => setEditContent(e.target.value)}
+                  />
+                  <div css={buttonContainerStyle}>
+                    <button css={saveButtonStyle} onClick={() => handleSaveClick(c.id)}>
+                      저장
+                    </button>
+                    <button css={cancelButtonStyle} onClick={handleCancelEdit}>
+                      취소
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div>{c.content}</div>
+                  <div css={dateStyle}>{new Date(c.date).toLocaleString("ko-KR")}</div>
+                  
+                  {canModifyComment(c) && (
+                    <div css={buttonContainerStyle}>
+                      <button css={editButtonStyle} onClick={() => handleEditClick(c)}>
+                        수정
+                      </button>
+                      <button css={deleteButtonStyle} onClick={() => handleDeleteClick(c.id)}>
+                        삭제
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          ))
+        ) : (
+          <div css={itemStyle}>{emptyText}</div>
+        )}
+      </div>
+
+      {/* 수정 확인 모달 */}
+      {saveConfirmId && ReactDOM.createPortal(
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>댓글을 수정하시겠습니까?</ModalTitle>
+            <ModalDesc>수정된 내용으로 변경됩니다.</ModalDesc>
+            <ModalButtonContainer>
+              <ModalButton variant="primary" onClick={handleConfirmSave}>
+                저장
+              </ModalButton>
+              <ModalButton variant="cancel" onClick={handleCancelSave}>
+                취소
+              </ModalButton>
+            </ModalButtonContainer>
+          </ModalContent>
+        </ModalOverlay>,
+        document.body
       )}
-    </div>
+
+      {/* 삭제 확인 모달 */}
+      {deleteConfirmId && ReactDOM.createPortal(
+        <ModalOverlay>
+          <ModalContent>
+            <ModalTitle>댓글을 삭제하시겠습니까?</ModalTitle>
+            <ModalDesc>삭제된 댓글은 복구할 수 없습니다.</ModalDesc>
+            <ModalButtonContainer>
+              <ModalButton variant="danger" onClick={handleConfirmDelete}>
+                삭제
+              </ModalButton>
+              <ModalButton variant="cancel" onClick={handleCancelDelete}>
+                취소
+              </ModalButton>
+            </ModalButtonContainer>
+          </ModalContent>
+        </ModalOverlay>,
+        document.body
+      )}
+    </>
   );
 };
 

--- a/src/hooks/admin/useDeleteSubmitComment.ts
+++ b/src/hooks/admin/useDeleteSubmitComment.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import deleteSubmitComment from "@/apis/admin/deleteSubmitComment";
+
+const useDeleteSubmitComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteSubmitComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adminActivityItem"] });
+      alert("댓글이 삭제되었습니다.");
+    },
+    onError: (error) => {
+      alert("댓글 삭제에 실패했습니다.");
+      console.error(error);
+    },
+  });
+};
+
+export default useDeleteSubmitComment;
+

--- a/src/hooks/admin/usePatchSubmitComment.ts
+++ b/src/hooks/admin/usePatchSubmitComment.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import patchSubmitComment from "@/apis/admin/patchSubmitComment";
+
+const usePatchSubmitComment = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchSubmitComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adminActivityItem"] });
+    },
+    onError: (error) => {
+      alert("댓글 수정에 실패했습니다.");
+      console.error(error);
+    },
+  });
+};
+
+export default usePatchSubmitComment;
+

--- a/src/pages/student/dashboard/components/ActivityPreviwItem.tsx
+++ b/src/pages/student/dashboard/components/ActivityPreviwItem.tsx
@@ -8,10 +8,12 @@ const categoryColor = {
 };
 
 interface ActivityPreviewItemProps {
-  title: string;
+  title?: string;
+  content: string;
   category: "LQ" | "RQ" | "CQ";
   status: 0 | 1 | 2;
   date?: string;
+  activityWeight?: number;
 }
 
 const getStatus = (status: number) => {
@@ -62,11 +64,32 @@ const statusStyle = (status: string) => {
   `;
 };
 
+const rightSideStyle = css`
+  display: flex;
+  align-items: center;
+`;
+
+const scoreStyle = css`
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #10b981; /* emerald */
+  margin-right: 10px;
+`;
+
+const scoreDividerStyle = css`
+  width: 1px;
+  height: 16px;
+  background: #e5e7eb;
+  margin: 0 10px 0 2px;
+`;
+
 const ActivityPreviewItem: React.FC<ActivityPreviewItemProps> = ({
   title,
+  content,
   category,
   status,
   date,
+  activityWeight,
 }) => (
   <div css={cardStyle}>
     <div style={{ display: "flex", alignItems: "center" }}>
@@ -78,7 +101,7 @@ const ActivityPreviewItem: React.FC<ActivityPreviewItemProps> = ({
           justifyContent: "center",
         }}
       >
-        <span css={titleStyle}>{title}</span>
+        <span css={titleStyle}>{title ?? content}</span>
         {date && (
           <span style={{ color: "#888", fontSize: "0.95rem", marginTop: 2 }}>
             {parseDate(date)}
@@ -86,7 +109,15 @@ const ActivityPreviewItem: React.FC<ActivityPreviewItemProps> = ({
         )}
       </div>
     </div>
-    <span css={statusStyle(getStatus(status))}>{getStatus(status)}</span>
+    <div css={rightSideStyle}>
+      {status === 1 && typeof activityWeight === "number" && (
+        <>
+          <span css={scoreStyle}>+{activityWeight}</span>
+          <span css={scoreDividerStyle} />
+        </>
+      )}
+      <span css={statusStyle(getStatus(status))}>{getStatus(status)}</span>
+    </div>
   </div>
 );
 

--- a/src/pages/student/dashboard/components/ApprovedActivitiesModal.tsx
+++ b/src/pages/student/dashboard/components/ApprovedActivitiesModal.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { css } from "@emotion/react";
+import ActivityPreviewItem from "./ActivityPreviwItem";
+import Loading from "@/components/layouts/Loading";
+import {
+  ModalOverlay,
+  ModalTitle,
+  ModalButton,
+  ModalButtonContainer,
+} from "@/styles/components/Modal";
+
+interface StudentActivity {
+  id: number;
+  title?: string;
+  content: string;
+  categoryName: string;
+  state: string;
+  approvedDate: string;
+  activityWeight?: number;
+}
+
+interface ApprovedActivitiesModalProps {
+  isOpen: boolean;
+  category: "LQ" | "RQ" | "CQ" | null;
+  activities: StudentActivity[];
+  isLoading: boolean;
+  onClose: () => void;
+}
+
+const modalContentLargeStyle = css`
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 32px;
+  max-width: 800px;
+  width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+`;
+
+const modalActivitiesContainerStyle = css`
+  margin-top: 24px;
+  max-height: 60vh;
+  overflow-y: auto;
+`;
+
+const emptyMessageStyle = css`
+  text-align: center;
+  padding: 40px 20px;
+  color: #666;
+`;
+
+const buttonContainerStyle = css`
+  margin-top: 24px;
+`;
+
+const getCategoryTitle = (category: "LQ" | "RQ" | "CQ") => {
+  switch (category) {
+    case "LQ":
+      return "Learning Quotient (LQ)";
+    case "RQ":
+      return "Research Quotient (RQ)";
+    case "CQ":
+      return "Creative Quotient (CQ)";
+    default:
+      return "";
+  }
+};
+
+const ApprovedActivitiesModal: React.FC<ApprovedActivitiesModalProps> = ({
+  isOpen,
+  category,
+  activities,
+  isLoading,
+  onClose,
+}) => {
+  if (!isOpen || !category) return null;
+
+  return (
+    <ModalOverlay onClick={onClose}>
+      <div css={modalContentLargeStyle} onClick={(e) => e.stopPropagation()}>
+        <ModalTitle>{getCategoryTitle(category)} - 승인된 활동 내역</ModalTitle>
+        <div css={modalActivitiesContainerStyle}>
+          {isLoading ? (
+            <Loading />
+          ) : activities.length > 0 ? (
+            activities.map((activity) => (
+              <ActivityPreviewItem
+                key={activity.id}
+                title={activity.title}
+                content={activity.content}
+                category={activity.categoryName as "LQ" | "RQ" | "CQ"}
+                status={parseInt(activity.state) as 0 | 1 | 2}
+                date={activity.approvedDate}
+                activityWeight={activity.activityWeight}
+              />
+            ))
+          ) : (
+            <div css={emptyMessageStyle}>승인된 활동 내역이 없습니다.</div>
+          )}
+        </div>
+        <ModalButtonContainer css={buttonContainerStyle}>
+          <ModalButton onClick={onClose}>닫기</ModalButton>
+        </ModalButtonContainer>
+      </div>
+    </ModalOverlay>
+  );
+};
+
+export default ApprovedActivitiesModal;
+

--- a/src/pages/student/dashboard/components/QCardVertical.tsx
+++ b/src/pages/student/dashboard/components/QCardVertical.tsx
@@ -8,6 +8,7 @@ interface QCardVerticalProps {
   score: number;
   percentage: number;
   average: number;
+  onViewAll?: () => void;
 }
 
 const cardStyle = css`
@@ -45,10 +46,26 @@ const textInfo = css`
   flex-direction: column;
 `;
 
+const titleContainerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 2px;
+`;
+
 const titleStyle = css`
   font-size: 1.2rem;
   font-weight: 700;
-  margin-bottom: 2px;
+`;
+
+const viewAllButtonStyle = css`
+  font-size: 0.9rem;
+  color: #888;
+  cursor: pointer;
+  transition: color 0.2s;
+  &:hover {
+    color: #555;
+  }
 `;
 
 const descriptionStyle = css`
@@ -107,6 +124,7 @@ const QCardVertical: React.FC<QCardVerticalProps> = ({
   score,
   percentage,
   average,
+  onViewAll,
 }) => {
   return (
     <div css={cardStyle}>
@@ -114,7 +132,14 @@ const QCardVertical: React.FC<QCardVerticalProps> = ({
         <div css={leftInfo}>
           <div css={dotStyle(category)} />
           <div css={textInfo}>
-            <span css={titleStyle}>{title}</span>
+            <div css={titleContainerStyle}>
+              <span css={titleStyle}>{title}</span>
+              {onViewAll && (
+                <span css={viewAllButtonStyle} onClick={onViewAll}>
+                  전체보기 &gt;
+                </span>
+              )}
+            </div>
             <span css={descriptionStyle}>{description}</span>
           </div>
         </div>

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { css } from "@emotion/react";
 import QCardVertical from "./components/QCardVertical";
 import GraphWrapper from "@/components/graphs/GraphWrapper";
@@ -6,6 +6,7 @@ import LineChart from "@/components/graphs/LineChart";
 import StackedBarChart from "@/components/graphs/StackedBarChart";
 import QuotientChart from "@/components/graphs/QuotientChart";
 import ActivityPreviewItem from "./components/ActivityPreviwItem";
+import ApprovedActivitiesModal from "./components/ApprovedActivitiesModal";
 import useStudent3qInfo from "@/hooks/student/useStudent3qInfo";
 import useStudent3qChange from "@/hooks/student/useStudent3qChange";
 import useStudent3qAverages from "@/hooks/student/useStudent3qAverages";
@@ -22,10 +23,12 @@ interface Student3qChange {
 
 interface StudentActivity {
   id: number;
+  title?: string;
   content: string;
   categoryName: string;
   state: string;
   approvedDate: string;
+  activityWeight?: number;
 }
 
 const titleStyle = css`
@@ -63,8 +66,21 @@ const viewAllButtonStyle = css`
   }
 `;
 
+const emptyMessageStyle = css`
+  text-align: center;
+  padding: 20px;
+  color: #666;
+`;
+
+const buttonContainerStyle = css`
+  margin-top: 16px;
+  width: 100%;
+`;
+
 const StudentDashboard: React.FC = () => {
   const navigate = useNavigate();
+  const [selectedCategory, setSelectedCategory] = useState<"LQ" | "RQ" | "CQ" | null>(null);
+  
   const { data: student3qInfo, isLoading: student3qInfoLoading } =
     useStudent3qInfo();
   const { data: student3qChange, isLoading: student3qChangeLoading } =
@@ -80,6 +96,15 @@ const StudentDashboard: React.FC = () => {
       sort: "desc",
     });
 
+  // 승인된 활동 내역 가져오기 (모달용)
+  const { data: approvedActivityList, isLoading: approvedActivityListLoading } =
+    useStudentActivityList({
+      state: 1, // 승인된 것만
+      page: 0,
+      size: 100, // 충분히 많은 수
+      sort: "desc",
+    });
+
   if (
     student3qInfoLoading ||
     student3qChangeLoading ||
@@ -88,6 +113,13 @@ const StudentDashboard: React.FC = () => {
   ) {
     return <Loading />;
   }
+
+  // 카테고리별 필터링된 승인 활동 내역
+  const filteredApprovedActivities = selectedCategory
+    ? approvedActivityList?.content?.filter(
+        (activity: StudentActivity) => activity.categoryName === selectedCategory
+      ) || []
+    : [];
 
   // 3Q 통계 데이터
   const QData = [
@@ -188,6 +220,7 @@ const StudentDashboard: React.FC = () => {
               score={q.score}
               percentage={q.percentage}
               average={q.average}
+              onViewAll={() => setSelectedCategory(q.category)}
             />
           ))}
         </div>
@@ -199,29 +232,18 @@ const StudentDashboard: React.FC = () => {
             studentActivityList.content.map((activity: StudentActivity) => (
               <ActivityPreviewItem
                 key={activity.id}
-                title={activity.content}
+                title={activity.title}
+                content={activity.content}
                 category={activity.categoryName as "LQ" | "RQ" | "CQ"}
                 status={parseInt(activity.state) as 0 | 1 | 2}
                 date={activity.approvedDate}
+                activityWeight={activity.activityWeight}
               />
             ))
           ) : (
-            <div
-              css={css`
-                text-align: center;
-                padding: 20px;
-                color: #666;
-              `}
-            >
-              등록된 활동 내역이 없습니다.
-            </div>
+            <div css={emptyMessageStyle}>등록된 활동 내역이 없습니다.</div>
           )}
-          <div
-            css={css`
-              margin-top: 16px;
-              width: 100%;
-            `}
-          >
+          <div css={buttonContainerStyle}>
             <button
               css={viewAllButtonStyle}
               onClick={() => {
@@ -244,6 +266,15 @@ const StudentDashboard: React.FC = () => {
             "학과별 비교": <StackedBarChart data={totalData} />,
           },
         }}
+      />
+
+      {/* 카테고리별 승인 활동 내역 모달 */}
+      <ApprovedActivitiesModal
+        isOpen={!!selectedCategory}
+        category={selectedCategory}
+        activities={filteredApprovedActivities}
+        isLoading={approvedActivityListLoading}
+        onClose={() => setSelectedCategory(null)}
       />
     </div>
   );

--- a/src/styles/components/Modal.tsx
+++ b/src/styles/components/Modal.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource @emotion/react */
+import styled from "@emotion/styled";
+
+export const ModalOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+`;
+
+export const ModalContent = styled.div`
+  background-color: #fff;
+  border-radius: 8px;
+  padding: 24px 32px;
+  max-width: 400px;
+  text-align: center;
+`;
+
+export const ModalTitle = styled.div`
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+`;
+
+export const ModalDesc = styled.div`
+  font-size: 0.875rem;
+  color: #666;
+  margin-bottom: 24px;
+`;
+
+export const ModalButtonContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+`;
+
+interface ModalButtonProps {
+  variant?: "primary" | "danger" | "cancel";
+}
+
+export const ModalButton = styled.button<ModalButtonProps>`
+  padding: 10px 28px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: all 0.15s;
+  border: ${({ variant }) =>
+    variant === "cancel" ? "1px solid #e0e0e0" : "none"};
+  background: ${({ variant }) =>
+    variant === "danger" ? "#dc2626" : variant === "cancel" ? "#f5f5f5" : "#2c2c2c"};
+  color: ${({ variant }) => (variant === "cancel" ? "#666" : "#fff")};
+
+  &:hover {
+    background: ${({ variant }) =>
+      variant === "danger"
+        ? "#b91c1c"
+        : variant === "cancel"
+        ? "#e8e8e8"
+        : "#1a1a1a"};
+  }
+`;
+

--- a/src/types/activitiy.d.ts
+++ b/src/types/activitiy.d.ts
@@ -14,6 +14,8 @@ export interface ActivityComment {
   id: number;
   content: string;
   date: string; // ISO string
+  userId: number;
+  userName: string;
 }
 
 


### PR DESCRIPTION
## 📌 PR 개요

간단한 요약을 적어주세요 (예: 어떤 기능을 추가했는지, 어떤 문제를 해결했는지 등)

## 🛠 작업 내용

<img width="1105" height="824" alt="image" src="https://github.com/user-attachments/assets/da7a477a-ed1a-42d4-894c-21d51ef2eaef" />

- [ ] student 대시보드에서 3Q지표요약의 지표 별 '전체 보기' 추가, 최근 활동 내역 content 표시 -> title 표시, 승인내역은 점수 같이 표기


<img width="1105" height="824" alt="image" src="https://github.com/user-attachments/assets/18ecf1b0-bf17-4300-8cfe-7695f79d70d7" />

- [ ] 전체보기 클릭 시 해당 지표 점수 산출 내역(승인 내역) 확인 가능. (근데 점수 안 맞는 경우 발견)

<img width="1105" height="824" alt="image" src="https://github.com/user-attachments/assets/7ec30827-f1f1-4b02-b02b-5d979b0216fd" />

- [ ] 활동내역 listitem 가독성을 위해 ui 수정. 승인내역은 점수 같이 표기
<img width="1146" height="824" alt="image" src="https://github.com/user-attachments/assets/184340a4-48f2-48d1-a04a-3f026fc6891b" />

- [ ] 새로운 활동 제출 시 form UI/UX 수정. 특히 활동 영역 분기, 제목 입력 추가, 레이아웃 수정.
<img width="1146" height="824" alt="image" src="https://github.com/user-attachments/assets/0663abe0-a295-4b41-8d68-20d129637eed" />

- [ ] 제출내역도 UI/UX 대폭 수정(제목 추가, 디자인 등)
<img width="351" height="415" alt="image" src="https://github.com/user-attachments/assets/e1491632-87fc-4501-bd08-a9d4bf5424ef" />


- [ ] 제출내역 수정/삭제 기능 추가. 댓글 모두 볼 수 있도록 수정
<img width="1146" height="824" alt="image" src="https://github.com/user-attachments/assets/871528c3-4c35-4a02-8e5b-ea0500cfd033" />

- [ ] Admin은 댓글 등록, 수정, 삭제 가능. 승인 상태는 댓글과 상관 없이 개별적으로 변경 가능.

- [ ] 각종 모달 스타일 통일, 컴포넌트화
- [ ] 코드 리팩토링

## 🖼 스크린샷 (선택)

## 🔗 연관된 이슈

- closes #이슈번호
