### PR TITLE
학생 통계 정규분포 2가지 추가, 관리자 통계의 개인별 통계 레이아웃, T점수 보기 추가

### DIFF
--- a/src/apis/admin/getStudentsList.ts
+++ b/src/apis/admin/getStudentsList.ts
@@ -1,6 +1,6 @@
 import axiosInstance from "@/apis/utils/axiosInterceptor";
 
-interface pageable {
+interface Pageable {
   name: string | null;
   department: string | null;
   page: number;
@@ -8,7 +8,30 @@ interface pageable {
   sort: string;
 }
 
-export const getStudentsList = async (pageable: pageable) => {
+export interface AdminStudentResponseItem {
+  id: number;
+  name: string;
+  department: string;
+  studentId: string;
+  grade: number;
+  lq: number;
+  rq: number;
+  cq: number;
+  totalScore: number;
+  tlq?: number | string | null;
+  trq?: number | string | null;
+  tcq?: number | string | null;
+}
+
+export interface StudentsListResponse {
+  content: AdminStudentResponseItem[];
+  totalPage: number;
+  totalElements?: number;
+}
+
+export const getStudentsList = async (
+  pageable: Pageable
+): Promise<StudentsListResponse> => {
   const response = await axiosInstance.get("/admin/students", {
     params: pageable,
   });

--- a/src/apis/student/getStudentMe.ts
+++ b/src/apis/student/getStudentMe.ts
@@ -1,0 +1,25 @@
+import axiosInstance from "@/apis/utils/axiosInterceptor";
+
+interface StudentMeResponse {
+  id: number;
+  name: string;
+  department: string;
+  studentId: string;
+  grade: number;
+  lq: number;
+  rq: number;
+  cq: number;
+  totalScore: number;
+  tlq: number;
+  tcq: number;
+  trq: number;
+}
+
+const getStudentMe = async (): Promise<StudentMeResponse> => {
+  const response = await axiosInstance.get("/student/me");
+  return response.data.data;
+};
+
+export default getStudentMe;
+export type { StudentMeResponse };
+

--- a/src/components/graphs/HorizontalBarChart.tsx
+++ b/src/components/graphs/HorizontalBarChart.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { css } from "@emotion/react";
+
+interface HorizontalBarChartProps {
+  data: Array<{
+    name: string;
+    LQ?: number;
+    RQ?: number;
+    CQ?: number;
+    value?: number;
+  }>;
+  title: string;
+  showStacked: boolean;
+  singleCategory?: "LQ" | "RQ" | "CQ";
+  showTScore?: boolean;
+}
+
+const chartTitleStyle = css`
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  text-align: center;
+  color: #333;
+`;
+
+const COLORS = {
+  LQ: "#0088FE",
+  RQ: "#00C49F",
+  CQ: "#FFBB28",
+};
+
+const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
+  data,
+  title,
+  showStacked,
+  singleCategory,
+  showTScore = false,
+}) => {
+  if (!data || data.length === 0) {
+    return (
+      <div style={{ width: "100%", height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <p style={{ color: "#999" }}>데이터가 없습니다</p>
+      </div>
+    );
+  }
+
+  // 최대값 계산
+  let calculatedMax = 0;
+  data.forEach(item => {
+    const value = item.value || 0;
+    if (value > calculatedMax) calculatedMax = value;
+  });
+
+  const maxValue = showTScore ? 100 : Math.ceil(calculatedMax * 1.1);
+  const chartHeight = 400;
+
+  return (
+    <div style={{ width: "100%", height: "100%", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+      <h3 css={chartTitleStyle}>{title}</h3>
+      <div style={{ flex: 1, overflow: "auto", width: "100%", minHeight: 0, display: "flex", alignItems: "flex-start" }}>
+        <div style={{ width: "100%", height: chartHeight }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ top: 20, right: 30, left: 20, bottom: 40 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                type="number"
+                domain={[0, maxValue]}
+                label={{ value: "점수", position: "insideBottom", offset: -10 }}
+                tick={{ fontSize: 11 }}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={80}
+                tick={{ fontSize: 11 }}
+              />
+              <Tooltip
+                formatter={(value: number) =>
+                  showTScore ? value.toFixed(2) : value.toFixed(1)
+                }
+              />
+              <Bar
+                dataKey="value"
+                fill={singleCategory ? COLORS[singleCategory] : "#667eea"}
+                name={showStacked ? "총점" : (singleCategory || "점수")}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HorizontalBarChart;
+

--- a/src/components/graphs/HorizontalBarChart.tsx
+++ b/src/components/graphs/HorizontalBarChart.tsx
@@ -61,19 +61,19 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
   });
 
   const maxValue = showTScore ? 100 : Math.ceil(calculatedMax * 1.1);
-  const chartHeight = 400;
+  // 학생 수에 따라 동적으로 높이 계산 (학생당 50px + 여백)
+  const chartHeight = Math.max(400, data.length * 50 + 100);
 
   return (
-    <div style={{ width: "100%", height: "100%", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+    <div style={{ width: "100%", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
       <h3 css={chartTitleStyle}>{title}</h3>
-      <div style={{ flex: 1, overflow: "auto", width: "100%", minHeight: 0, display: "flex", alignItems: "flex-start" }}>
-        <div style={{ width: "100%", height: chartHeight }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={data}
-              layout="vertical"
-              margin={{ top: 20, right: 30, left: 20, bottom: 40 }}
-            >
+      <div style={{ width: "100%", minHeight: chartHeight }}>
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <BarChart
+            data={data}
+            layout="vertical"
+            margin={{ top: 20, right: 30, left: 20, bottom: 40 }}
+          >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis
                 type="number"
@@ -98,8 +98,7 @@ const HorizontalBarChart: React.FC<HorizontalBarChartProps> = ({
                 name={showStacked ? "총점" : (singleCategory || "점수")}
               />
             </BarChart>
-          </ResponsiveContainer>
-        </div>
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/src/components/graphs/IndividualDistribution.tsx
+++ b/src/components/graphs/IndividualDistribution.tsx
@@ -1,0 +1,221 @@
+import React from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { css } from "@emotion/react";
+import { generateNormalDistributionData } from "@/utils/normalDistribution";
+
+interface IndividualDistributionProps {
+  tlq: number;
+  trq: number;
+  tcq: number;
+}
+
+const chartContainer = css`
+  width: 100%;
+  height: 500px;
+  padding: 20px;
+`;
+
+const titleStyle = css`
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: #333;
+`;
+
+const descriptionStyle = css`
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 20px;
+  line-height: 1.5;
+`;
+
+const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
+  tlq,
+  trq,
+  tcq,
+}) => {
+  // T-점수는 3개 영역 합이 평균 50이 되도록 설계
+  // 따라서 각 영역의 평균은 50/3 ≈ 16.67
+  const mean = 50 / 3;  // ≈ 16.67
+  const stdDev = 10;
+  
+  // 0부터 평균의 2배까지 표시하므로 range를 조정 (약 ±1.67σ)
+  const normalData = generateNormalDistributionData(mean, stdDev, 100, 2);
+
+  // 각 지수의 백분위 계산 (개별 영역 기준)
+  const calculatePercentile = (value: number, mean: number, stdDev: number): number => {
+    const z = (value - mean) / stdDev;
+    const t = 1 / (1 + 0.2316419 * Math.abs(z));
+    const d = 0.3989423 * Math.exp((-z * z) / 2);
+    const probability =
+      d *
+      t *
+      (0.3193815 +
+        t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+    return z >= 0 ? (1 - probability) * 100 : probability * 100;
+  };
+  
+  const lqPercentile = calculatePercentile(tlq, mean, stdDev);
+  const rqPercentile = calculatePercentile(trq, mean, stdDev);
+  const cqPercentile = calculatePercentile(tcq, mean, stdDev);
+
+  // Recharts용 데이터 변환
+  const chartData = normalData.map((point) => ({
+    tScore: point.x,
+    density: point.y,
+  }));
+
+  // X축 범위: 0부터 평균의 2배까지
+  const xDomain = [0, mean * 2];  // 0 ~ 33.34
+  
+  // X축 tick 설정 (5 단위)
+  const xTicks = [0, 5, 10, 15, Math.round(mean * 10) / 10, 20, 25, 30, Math.round(mean * 2 * 10) / 10];
+
+  return (
+    <div>
+      <h3 css={titleStyle}>개별 3Q 지수 분포</h3>
+      <p css={descriptionStyle}>
+        LQ, RQ, CQ 각 지수의 T-점수 분포입니다 (각 영역 평균: {mean.toFixed(2)}점). 수직선은 귀하의 점수 위치를 나타냅니다.
+        <br />
+        <strong style={{ color: "#0066CC" }}>LQ: {tlq.toFixed(1)}점</strong> (상위 {Math.max(0, Math.min(100, 100 - lqPercentile)).toFixed(1)}%) |{" "}
+        <strong style={{ color: "#00A878" }}>RQ: {trq.toFixed(1)}점</strong> (상위 {Math.max(0, Math.min(100, 100 - rqPercentile)).toFixed(1)}%) |{" "}
+        <strong style={{ color: "#FFA500" }}>CQ: {tcq.toFixed(1)}점</strong> (상위 {Math.max(0, Math.min(100, 100 - cqPercentile)).toFixed(1)}%)
+      </p>
+      <div css={chartContainer}>
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart
+            data={chartData}
+            margin={{
+              top: 80,
+              right: 30,
+              left: 10,
+              bottom: 60,
+            }}
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="tScore"
+              label={{ value: "T-점수", position: "insideBottom", offset: -5 }}
+              domain={xDomain}
+              type="number"
+              ticks={xTicks}
+            />
+            <YAxis
+              label={{ value: "확률 밀도", angle: -90, position: "insideLeft" }}
+            />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (active && payload && payload.length) {
+                  return (
+                    <div
+                      style={{
+                        background: "white",
+                        padding: "10px",
+                        borderRadius: "4px",
+                        boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+                        border: "1px solid #ddd",
+                      }}
+                    >
+                      <p style={{ margin: 0, fontWeight: "bold" }}>
+                        T-점수: {payload[0].payload.tScore.toFixed(1)}
+                      </p>
+                    </div>
+                  );
+                }
+                return null;
+              }}
+            />
+            {/* 정규분포 곡선 */}
+            <Area
+              type="monotone"
+              dataKey="density"
+              stroke="#8884d8"
+              fill="#8884d8"
+              fillOpacity={0.1}
+              name="표준 정규분포"
+              strokeWidth={2}
+            />
+
+            {/* 평균선 (16.67) */}
+            <ReferenceLine
+              x={mean}
+              stroke="#999"
+              strokeDasharray="5 5"
+              label={{
+                value: `평균: ${mean.toFixed(2)}`,
+                position: "top",
+                fill: "#999",
+                fontSize: 11,
+                offset: 65,
+              }}
+            />
+
+            {/* 학생의 T-점수 위치 표시 - 그래프 위쪽에 배치 */}
+            <ReferenceLine
+              x={tlq}
+              stroke="#0066CC"
+              strokeWidth={2.5}
+              strokeDasharray="0"
+              label={{
+                value: `LQ: ${tlq.toFixed(1)}`,
+                position: "top",
+                fill: "#0066CC",
+                fontWeight: "bold",
+                fontSize: 12,
+                offset: 5,
+              }}
+              isFront={true}
+            />
+            <ReferenceLine
+              x={trq}
+              stroke="#00A878"
+              strokeWidth={2.5}
+              strokeDasharray="0"
+              label={{
+                value: `RQ: ${trq.toFixed(1)}`,
+                position: "top",
+                fill: "#00A878",
+                fontWeight: "bold",
+                fontSize: 12,
+                offset: 25,
+              }}
+              isFront={true}
+            />
+            <ReferenceLine
+              x={tcq}
+              stroke="#FFA500"
+              strokeWidth={2.5}
+              strokeDasharray="0"
+              label={{
+                value: `CQ: ${tcq.toFixed(1)}`,
+                position: "top",
+                fill: "#FFA500",
+                fontWeight: "bold",
+                fontSize: 12,
+                offset: 45,
+              }}
+              isFront={true}
+            />
+            
+            <Legend
+              verticalAlign="bottom"
+              wrapperStyle={{ paddingTop: "20px" }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default IndividualDistribution;

--- a/src/components/graphs/IndividualDistribution.tsx
+++ b/src/components/graphs/IndividualDistribution.tsx
@@ -96,7 +96,7 @@ const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
           <AreaChart
             data={chartData}
             margin={{
-              top: 80,
+              top: 20,
               right: 30,
               left: 10,
               bottom: 60,
@@ -116,6 +116,60 @@ const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
             <Tooltip
               content={({ active, payload }) => {
                 if (active && payload && payload.length) {
+                  const currentX = payload[0].payload.tScore;
+                  const threshold = 1.5; // 수직선 근처 판단 기준
+
+                  // 각 점수와의 거리 계산
+                  const distToLQ = Math.abs(currentX - tlq);
+                  const distToRQ = Math.abs(currentX - trq);
+                  const distToCQ = Math.abs(currentX - tcq);
+
+                  // 가장 가까운 점수 찾기
+                  const minDist = Math.min(distToLQ, distToRQ, distToCQ);
+
+                  // 수직선 근처인 경우 해당 점수의 특별 툴팁 표시
+                  if (minDist <= threshold) {
+                    let color, label, score, percentile;
+                    
+                    if (minDist === distToLQ) {
+                      color = "#0066CC";
+                      label = "LQ";
+                      score = tlq;
+                      percentile = lqPercentile;
+                    } else if (minDist === distToRQ) {
+                      color = "#00A878";
+                      label = "RQ";
+                      score = trq;
+                      percentile = rqPercentile;
+                    } else {
+                      color = "#FFA500";
+                      label = "CQ";
+                      score = tcq;
+                      percentile = cqPercentile;
+                    }
+
+                    return (
+                      <div
+                        style={{
+                          background: color,
+                          color: "white",
+                          padding: "12px 16px",
+                          borderRadius: "8px",
+                          boxShadow: "0 4px 8px rgba(0,0,0,0.2)",
+                          border: `2px solid ${color}`,
+                        }}
+                      >
+                        <p style={{ margin: 0, fontWeight: "bold", fontSize: "14px" }}>
+                          {label}: {score.toFixed(1)}점
+                        </p>
+                        <p style={{ margin: "4px 0 0 0", fontSize: "12px" }}>
+                          상위 {Math.max(0, Math.min(100, 100 - percentile)).toFixed(1)}%
+                        </p>
+                      </div>
+                    );
+                  }
+
+                  // 기본 툴팁 (수직선 근처가 아닌 경우)
                   return (
                     <div
                       style={{
@@ -127,7 +181,7 @@ const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
                       }}
                     >
                       <p style={{ margin: 0, fontWeight: "bold" }}>
-                        T-점수: {payload[0].payload.tScore.toFixed(1)}
+                        T-점수: {currentX.toFixed(1)}
                       </p>
                     </div>
                   );
@@ -146,34 +200,19 @@ const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
               strokeWidth={2}
             />
 
-            {/* 평균선 (16.67) */}
+            {/* 평균선 (16.67) - 레이블 제거 */}
             <ReferenceLine
               x={mean}
               stroke="#999"
               strokeDasharray="5 5"
-              label={{
-                value: `평균: ${mean.toFixed(2)}`,
-                position: "top",
-                fill: "#999",
-                fontSize: 11,
-                offset: 65,
-              }}
             />
 
-            {/* 학생의 T-점수 위치 표시 - 그래프 위쪽에 배치 */}
+            {/* 학생의 T-점수 위치 표시 - 레이블 제거 */}
             <ReferenceLine
               x={tlq}
               stroke="#0066CC"
               strokeWidth={2.5}
               strokeDasharray="0"
-              label={{
-                value: `LQ: ${tlq.toFixed(1)}`,
-                position: "top",
-                fill: "#0066CC",
-                fontWeight: "bold",
-                fontSize: 12,
-                offset: 5,
-              }}
               isFront={true}
             />
             <ReferenceLine
@@ -181,14 +220,6 @@ const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
               stroke="#00A878"
               strokeWidth={2.5}
               strokeDasharray="0"
-              label={{
-                value: `RQ: ${trq.toFixed(1)}`,
-                position: "top",
-                fill: "#00A878",
-                fontWeight: "bold",
-                fontSize: 12,
-                offset: 25,
-              }}
               isFront={true}
             />
             <ReferenceLine
@@ -196,14 +227,6 @@ const IndividualDistribution: React.FC<IndividualDistributionProps> = ({
               stroke="#FFA500"
               strokeWidth={2.5}
               strokeDasharray="0"
-              label={{
-                value: `CQ: ${tcq.toFixed(1)}`,
-                position: "top",
-                fill: "#FFA500",
-                fontWeight: "bold",
-                fontSize: 12,
-                offset: 45,
-              }}
               isFront={true}
             />
             

--- a/src/components/graphs/LineChart.tsx
+++ b/src/components/graphs/LineChart.tsx
@@ -38,16 +38,22 @@ const LineChart: React.FC<LineChartProps> = ({ data }) => {
             top: 5,
             right: 30,
             left: 20,
-            bottom: 5,
+            bottom: 25,
           }}
         >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="year" label={{ value: "연도", position: "bottom" }} />
+          <XAxis 
+            dataKey="year" 
+            label={{ value: "연도-월", position: "insideBottom", offset: -5 }} 
+          />
           <YAxis
             label={{ value: "점수", angle: -90, position: "insideLeft" }}
           />
           <Tooltip />
-          <Legend />
+          <Legend 
+            verticalAlign="bottom" 
+            wrapperStyle={{ paddingTop: "20px" }} 
+          />
           <Line
             type="monotone"
             dataKey="LQ"

--- a/src/components/graphs/MyDistribution.tsx
+++ b/src/components/graphs/MyDistribution.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { css } from "@emotion/react";
+import IndividualDistribution from "./IndividualDistribution";
+import TotalDistribution from "./TotalDistribution";
+import Card from "@/styles/components/Card";
+
+interface MyDistributionProps {
+  tlq: number;
+  trq: number;
+  tcq: number;
+}
+
+const containerStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+`;
+
+const cardStyle = css`
+  padding: 32px;
+  background: white;
+  border-radius: 12px;
+`;
+
+const dividerStyle = css`
+  height: 2px;
+  background: linear-gradient(to right, transparent, #e0e0e0, transparent);
+  margin: 16px 0;
+`;
+
+const MyDistribution: React.FC<MyDistributionProps> = ({ tlq, trq, tcq }) => {
+  return (
+    <div css={containerStyle}>
+      {/* 개별 3Q 지수 분포 */}
+      <Card css={cardStyle}>
+        <IndividualDistribution tlq={tlq} trq={trq} tcq={tcq} />
+      </Card>
+
+      <div css={dividerStyle} />
+
+      {/* 총 3Q 점수 분포 */}
+      <Card css={cardStyle}>
+        <TotalDistribution tlq={tlq} trq={trq} tcq={tcq} />
+      </Card>
+    </div>
+  );
+};
+
+export default MyDistribution;
+

--- a/src/components/graphs/SimpleBarChart.tsx
+++ b/src/components/graphs/SimpleBarChart.tsx
@@ -40,15 +40,15 @@ const tooltipItemStyle = css`
 
 const chartContainerStyle = css`
   width: 100%;
-  height: 300px;
+  height: 350px;
 `;
 
 const titleStyle = css`
-  font-size: 1.2rem;
-  font-weight: bold;
-  margin-bottom: 15px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  text-align: start;
   color: #333;
-  text-align: center;
 `;
 
 const barColorMap: Record<string, string> = {
@@ -72,17 +72,20 @@ const SimpleBarChart: React.FC<SimpleBarChartProps> = ({
     }));
 
   return (
-    <div>
-      <div css={titleStyle}>{title}</div>
+    <div style={{ width: "100%", height: "100%", display: "flex", flexDirection: "column" }}>
+      <h3 css={titleStyle}>{title}</h3>
       <div css={chartContainerStyle}>
         <ResponsiveContainer width="100%" height="100%">
           <BarChart
             data={chartData}
-            margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+            margin={{ top: 20, right: 30, left: 20, bottom: 20 }}
           >
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis dataKey="name" />
-            <YAxis domain={showTScore ? [0, 100] : [0, 33]} />
+            <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+            <YAxis 
+              domain={showTScore ? [0, 100] : [0, 33]} 
+              tick={{ fontSize: 11 }}
+            />
             <Tooltip
               content={({ active, payload, label }) => {
                 if (active && payload && payload.length) {

--- a/src/components/graphs/SimpleBarChart.tsx
+++ b/src/components/graphs/SimpleBarChart.tsx
@@ -10,13 +10,12 @@ import {
 } from "recharts";
 import { css } from "@emotion/react";
 
+type ChartDataRecord = Record<string, number | undefined>;
+
 interface SimpleBarChartProps {
-  data: {
-    LQ: number;
-    RQ: number;
-    CQ: number;
-  };
+  data: ChartDataRecord;
   title: string;
+  showTScore?: boolean;
 }
 
 const tooltipContainerStyle = css`
@@ -52,12 +51,25 @@ const titleStyle = css`
   text-align: center;
 `;
 
-const SimpleBarChart: React.FC<SimpleBarChartProps> = ({ data, title }) => {
-  const chartData = [
-    { name: "LQ", value: data.LQ, fill: "#0088FE" },
-    { name: "RQ", value: data.RQ, fill: "#00C49F" },
-    { name: "CQ", value: data.CQ, fill: "#FFBB28" },
-  ];
+const barColorMap: Record<string, string> = {
+  LQ: "#0088FE",
+  RQ: "#00C49F",
+  CQ: "#FFBB28",
+  "T-합계": "#845EC2",
+};
+
+const SimpleBarChart: React.FC<SimpleBarChartProps> = ({
+  data,
+  title,
+  showTScore = false,
+}) => {
+  const chartData = Object.entries(data)
+    .filter(([, value]) => typeof value === "number" && !Number.isNaN(value))
+    .map(([name, value]) => ({
+      name,
+      value: value as number,
+      fill: barColorMap[name] ?? "#8884d8",
+    }));
 
   return (
     <div>
@@ -70,14 +82,20 @@ const SimpleBarChart: React.FC<SimpleBarChartProps> = ({ data, title }) => {
           >
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="name" />
-            <YAxis domain={[0, 33]} />
+            <YAxis domain={showTScore ? [0, 100] : [0, 33]} />
             <Tooltip
               content={({ active, payload, label }) => {
                 if (active && payload && payload.length) {
                   return (
                     <div css={tooltipContainerStyle}>
                       <p css={tooltipTitleStyle}>{label}</p>
-                      <p css={tooltipItemStyle}>점수: {payload[0]?.value}점</p>
+                      <p css={tooltipItemStyle}>
+                        점수:{" "}
+                        {showTScore
+                          ? Number(payload[0]?.value).toFixed(2)
+                          : payload[0]?.value}
+                        점
+                      </p>
                     </div>
                   );
                 }

--- a/src/components/graphs/TotalDistribution.tsx
+++ b/src/components/graphs/TotalDistribution.tsx
@@ -98,7 +98,7 @@ const TotalDistribution: React.FC<TotalDistributionProps> = ({
     if (score >= mean + 2 * stdDev) return "매우 우수 (상위 2.3%)";
     if (score >= mean + stdDev) return "우수 (상위 16%)";
     if (score >= mean) return "평균 이상";
-    if (score >= mean - stdDev) return "평균";
+    if (score >= mean - stdDev) return "평균 수준";
     if (score >= mean - 2 * stdDev) return "개선 필요 (하위 16%)";
     return "많은 노력 필요 (하위 2.3%)";
   };
@@ -119,7 +119,7 @@ const TotalDistribution: React.FC<TotalDistributionProps> = ({
           <AreaChart
             data={chartData}
             margin={{
-              top: 60,
+              top: 20,
               right: 30,
               left: 10,
               bottom: 60,
@@ -145,7 +145,39 @@ const TotalDistribution: React.FC<TotalDistributionProps> = ({
             <Tooltip
               content={({ active, payload }) => {
                 if (active && payload && payload.length) {
-                  const score = payload[0].payload.tScore;
+                  const currentX = payload[0].payload.tScore;
+                  const threshold = 3; // 수직선 근처 판단 기준 (총점은 범위가 넓어서 조금 더 크게)
+
+                  // 내 점수 수직선 근처인지 확인
+                  const distToMyScore = Math.abs(currentX - totalTScore);
+
+                  if (distToMyScore <= threshold) {
+                    // 내 점수 근처: 빨간색 특별 툴팁
+                    return (
+                      <div
+                        style={{
+                          background: "#ff4757",
+                          color: "white",
+                          padding: "12px 16px",
+                          borderRadius: "8px",
+                          boxShadow: "0 4px 8px rgba(0,0,0,0.2)",
+                          border: "2px solid #ff4757",
+                        }}
+                      >
+                        <p style={{ margin: 0, fontWeight: "bold", fontSize: "14px" }}>
+                          내 총 T-점수: {totalTScore.toFixed(1)}점
+                        </p>
+                        <p style={{ margin: "4px 0 0 0", fontSize: "12px" }}>
+                          상위 {(100 - percentile).toFixed(1)}%
+                        </p>
+                        <p style={{ margin: "4px 0 0 0", fontSize: "12px" }}>
+                          {scoreLevel}
+                        </p>
+                      </div>
+                    );
+                  }
+
+                  // 기본 툴팁 (수직선 근처가 아닌 경우)
                   return (
                     <div
                       style={{
@@ -157,10 +189,10 @@ const TotalDistribution: React.FC<TotalDistributionProps> = ({
                       }}
                     >
                       <p style={{ margin: 0, fontWeight: "bold" }}>
-                        총 T-점수: {score.toFixed(1)}
+                        총 T-점수: {currentX.toFixed(1)}
                       </p>
                       <p style={{ margin: "4px 0 0 0", fontSize: "0.9rem" }}>
-                        {getScoreLevel(score)}
+                        {getScoreLevel(currentX)}
                       </p>
                     </div>
                   );
@@ -178,34 +210,19 @@ const TotalDistribution: React.FC<TotalDistributionProps> = ({
               strokeWidth={2}
             />
 
-            {/* 평균선 - 위쪽에 배치 */}
+            {/* 평균선 - 레이블 제거 */}
             <ReferenceLine
               x={mean}
               stroke="#999"
               strokeDasharray="5 5"
-              label={{
-                value: `평균: ${mean.toFixed(0)}`,
-                position: "top",
-                fill: "#999",
-                fontSize: 12,
-                offset: 30,
-              }}
             />
 
-            {/* 학생의 총 T-점수 위치 - 그래프 위쪽에 배치 */}
+            {/* 학생의 총 T-점수 위치 - 레이블 제거 */}
             <ReferenceLine
               x={totalTScore}
               stroke="#ff4757"
               strokeWidth={2.5}
               strokeDasharray="0"
-              label={{
-                value: `내 점수: ${totalTScore.toFixed(1)}`,
-                position: "top",
-                fill: "#ff4757",
-                fontWeight: "bold",
-                fontSize: 13,
-                offset: 10,
-              }}
               isFront={true}
             />
             

--- a/src/components/graphs/TotalDistribution.tsx
+++ b/src/components/graphs/TotalDistribution.tsx
@@ -1,0 +1,246 @@
+import React from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { css } from "@emotion/react";
+import { generateNormalDistributionData } from "@/utils/normalDistribution";
+
+interface TotalDistributionProps {
+  tlq: number;
+  trq: number;
+  tcq: number;
+}
+
+const chartContainer = css`
+  width: 100%;
+  height: 500px;
+  padding: 20px;
+`;
+
+const titleStyle = css`
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  color: #333;
+`;
+
+const descriptionStyle = css`
+  font-size: 0.9rem;
+  color: #666;
+  margin-bottom: 20px;
+  line-height: 1.5;
+`;
+
+const scoreBoxStyle = css`
+  display: inline-block;
+  background: #f8f9fa;
+  color: #333;
+  padding: 16px 32px;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 16px;
+  border: 2px solid #e0e0e0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+`;
+
+const TotalDistribution: React.FC<TotalDistributionProps> = ({
+  tlq,
+  trq,
+  tcq,
+}) => {
+  // 총 T-점수 계산
+  const totalTScore = tlq + trq + tcq;
+
+  // T-점수 총합: 평균 50 (3개 영역 합), 표준편차 약 17.32 (√(10²+10²+10²))
+  const mean = 50;
+  const stdDev = Math.sqrt(10 * 10 + 10 * 10 + 10 * 10); // ≈ 17.32
+
+  // 0부터 평균의 2배까지 표시하므로 range를 조정 (약 ±2.89σ)
+  const normalData = generateNormalDistributionData(mean, stdDev, 150, 3);
+
+  // Recharts용 데이터 변환
+  const chartData = normalData.map((point) => ({
+    tScore: point.x,
+    density: point.y,
+  }));
+
+  // X축 범위: 0부터 평균의 2배까지
+  const xDomain = [0, mean * 2];  // 0 ~ 100
+  
+  // X축 tick 설정 (10 단위)
+  const xTicks = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+  // 백분위 계산 (Z-score 기반)
+  const zScore = (totalTScore - mean) / stdDev;
+  const calculatePercentile = (z: number): number => {
+    const t = 1 / (1 + 0.2316419 * Math.abs(z));
+    const d = 0.3989423 * Math.exp((-z * z) / 2);
+    const probability =
+      d *
+      t *
+      (0.3193815 +
+        t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+    return z >= 0 ? (1 - probability) * 100 : probability * 100;
+  };
+  const percentile = calculatePercentile(zScore);
+
+  // 표준편차 구간 표시
+  const getScoreLevel = (score: number): string => {
+    if (score >= mean + 2 * stdDev) return "매우 우수 (상위 2.3%)";
+    if (score >= mean + stdDev) return "우수 (상위 16%)";
+    if (score >= mean) return "평균 이상";
+    if (score >= mean - stdDev) return "평균";
+    if (score >= mean - 2 * stdDev) return "개선 필요 (하위 16%)";
+    return "많은 노력 필요 (하위 2.3%)";
+  };
+
+  const scoreLevel = getScoreLevel(totalTScore);
+
+  return (
+    <div>
+      <h3 css={titleStyle}>총 3Q 점수 분포</h3>
+      <p css={descriptionStyle}>
+        LQ + RQ + CQ를 합한 총 T-점수의 분포입니다 (평균: {mean}점). 전체 학생 중 귀하의 위치를 확인할 수 있습니다.
+      </p>
+      <div css={scoreBoxStyle}>
+        총 T-점수: {totalTScore.toFixed(1)}점 | 상위 {(100 - percentile).toFixed(1)}% | {scoreLevel}
+      </div>
+      <div css={chartContainer}>
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart
+            data={chartData}
+            margin={{
+              top: 60,
+              right: 30,
+              left: 10,
+              bottom: 60,
+            }}
+          >
+            <defs>
+              <linearGradient id="colorTotal" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#667eea" stopOpacity={0.8} />
+                <stop offset="95%" stopColor="#764ba2" stopOpacity={0.2} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis
+              dataKey="tScore"
+              label={{ value: "총 T-점수", position: "insideBottom", offset: -5 }}
+              domain={xDomain}
+              type="number"
+              ticks={xTicks}
+            />
+            <YAxis
+              label={{ value: "확률 밀도", angle: -90, position: "insideLeft" }}
+            />
+            <Tooltip
+              content={({ active, payload }) => {
+                if (active && payload && payload.length) {
+                  const score = payload[0].payload.tScore;
+                  return (
+                    <div
+                      style={{
+                        background: "white",
+                        padding: "10px",
+                        borderRadius: "4px",
+                        boxShadow: "0 2px 4px rgba(0,0,0,0.1)",
+                        border: "1px solid #ddd",
+                      }}
+                    >
+                      <p style={{ margin: 0, fontWeight: "bold" }}>
+                        총 T-점수: {score.toFixed(1)}
+                      </p>
+                      <p style={{ margin: "4px 0 0 0", fontSize: "0.9rem" }}>
+                        {getScoreLevel(score)}
+                      </p>
+                    </div>
+                  );
+                }
+                return null;
+              }}
+            />
+            {/* 정규분포 곡선 */}
+            <Area
+              type="monotone"
+              dataKey="density"
+              stroke="#667eea"
+              fill="url(#colorTotal)"
+              name="전체 학생 분포"
+              strokeWidth={2}
+            />
+
+            {/* 평균선 - 위쪽에 배치 */}
+            <ReferenceLine
+              x={mean}
+              stroke="#999"
+              strokeDasharray="5 5"
+              label={{
+                value: `평균: ${mean.toFixed(0)}`,
+                position: "top",
+                fill: "#999",
+                fontSize: 12,
+                offset: 30,
+              }}
+            />
+
+            {/* 학생의 총 T-점수 위치 - 그래프 위쪽에 배치 */}
+            <ReferenceLine
+              x={totalTScore}
+              stroke="#ff4757"
+              strokeWidth={2.5}
+              strokeDasharray="0"
+              label={{
+                value: `내 점수: ${totalTScore.toFixed(1)}`,
+                position: "top",
+                fill: "#ff4757",
+                fontWeight: "bold",
+                fontSize: 13,
+                offset: 10,
+              }}
+              isFront={true}
+            />
+            
+            <Legend
+              verticalAlign="bottom"
+              wrapperStyle={{ paddingTop: "20px" }}
+            />
+
+            {/* ±1σ, ±2σ 구간 표시 */}
+            <ReferenceLine
+              x={mean - stdDev}
+              stroke="#ddd"
+              strokeDasharray="3 3"
+            />
+            <ReferenceLine
+              x={mean + stdDev}
+              stroke="#ddd"
+              strokeDasharray="3 3"
+            />
+            <ReferenceLine
+              x={mean - 2 * stdDev}
+              stroke="#eee"
+              strokeDasharray="3 3"
+            />
+            <ReferenceLine
+              x={mean + 2 * stdDev}
+              stroke="#eee"
+              strokeDasharray="3 3"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default TotalDistribution;
+

--- a/src/components/table/SelectedUsersTable.tsx
+++ b/src/components/table/SelectedUsersTable.tsx
@@ -30,6 +30,7 @@ interface SelectedUsersTableProps {
   users: User[];
   onUserRemove: (userId: number) => void;
   showTScore?: boolean;
+  onUserClick?: (user: User) => void;
 }
 
 type SortField = "name" | "lq" | "rq" | "cq" | "total";
@@ -88,6 +89,7 @@ const SelectedUsersTable: React.FC<SelectedUsersTableProps> = ({
   users,
   onUserRemove,
   showTScore = false,
+  onUserClick,
 }) => {
   const [sortField, setSortField] = useState<SortField>("name");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
@@ -239,7 +241,11 @@ const SelectedUsersTable: React.FC<SelectedUsersTableProps> = ({
           </TableHead>
           <TableBody>
             {paginatedUsers.map((user) => (
-              <TableRow key={user.id} css={tableRowStyle}>
+              <TableRow 
+                key={user.id} 
+                css={tableRowStyle}
+                onClick={() => onUserClick?.(user)}
+              >
                 <TableCell css={nameCellStyle}>{user.name}</TableCell>
                 <TableCell css={scoreCellStyle}>
                   {showTScore ? (user.tlq || 0).toFixed(2) : user.lq}

--- a/src/components/table/SelectedUsersTable.tsx
+++ b/src/components/table/SelectedUsersTable.tsx
@@ -20,11 +20,16 @@ interface User {
   rq: number;
   cq: number;
   totalScore: number;
+  tlq?: number;
+  trq?: number;
+  tcq?: number;
+  totalTScore?: number;
 }
 
 interface SelectedUsersTableProps {
   users: User[];
   onUserRemove: (userId: number) => void;
+  showTScore?: boolean;
 }
 
 type SortField = "name" | "lq" | "rq" | "cq" | "total";
@@ -82,6 +87,7 @@ const deleteButtonStyle = css`
 const SelectedUsersTable: React.FC<SelectedUsersTableProps> = ({
   users,
   onUserRemove,
+  showTScore = false,
 }) => {
   const [sortField, setSortField] = useState<SortField>("name");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
@@ -99,20 +105,20 @@ const SelectedUsersTable: React.FC<SelectedUsersTableProps> = ({
         bValue = `${b.name} ${b.studentId}`;
         break;
       case "lq":
-        aValue = a.lq;
-        bValue = b.lq;
+        aValue = showTScore ? (a.tlq || 0) : a.lq;
+        bValue = showTScore ? (b.tlq || 0) : b.lq;
         break;
       case "rq":
-        aValue = a.rq;
-        bValue = b.rq;
+        aValue = showTScore ? (a.trq || 0) : a.rq;
+        bValue = showTScore ? (b.trq || 0) : b.rq;
         break;
       case "cq":
-        aValue = a.cq;
-        bValue = b.cq;
+        aValue = showTScore ? (a.tcq || 0) : a.cq;
+        bValue = showTScore ? (b.tcq || 0) : b.cq;
         break;
       case "total":
-        aValue = a.totalScore;
-        bValue = b.totalScore;
+        aValue = showTScore ? (a.totalTScore || 0) : a.totalScore;
+        bValue = showTScore ? (b.totalTScore || 0) : b.totalScore;
         break;
       default:
         aValue = a.name;
@@ -235,10 +241,18 @@ const SelectedUsersTable: React.FC<SelectedUsersTableProps> = ({
             {paginatedUsers.map((user) => (
               <TableRow key={user.id} css={tableRowStyle}>
                 <TableCell css={nameCellStyle}>{user.name}</TableCell>
-                <TableCell css={scoreCellStyle}>{user.lq}</TableCell>
-                <TableCell css={scoreCellStyle}>{user.rq}</TableCell>
-                <TableCell css={scoreCellStyle}>{user.cq}</TableCell>
-                <TableCell css={scoreCellStyle}>{user.totalScore}</TableCell>
+                <TableCell css={scoreCellStyle}>
+                  {showTScore ? (user.tlq || 0).toFixed(2) : user.lq}
+                </TableCell>
+                <TableCell css={scoreCellStyle}>
+                  {showTScore ? (user.trq || 0).toFixed(2) : user.rq}
+                </TableCell>
+                <TableCell css={scoreCellStyle}>
+                  {showTScore ? (user.tcq || 0).toFixed(2) : user.cq}
+                </TableCell>
+                <TableCell css={scoreCellStyle}>
+                  {showTScore ? (user.totalTScore || 0).toFixed(2) : user.totalScore}
+                </TableCell>
                 <TableCell css={tableCellStyle} align="center">
                   <IconButton
                     css={deleteButtonStyle}

--- a/src/hooks/admin/useStudentsList.ts
+++ b/src/hooks/admin/useStudentsList.ts
@@ -1,7 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import getStudentsList from "@/apis/admin/getStudentsList";
+import getStudentsList, {
+  StudentsListResponse,
+} from "@/apis/admin/getStudentsList";
 
-interface pageable {
+export interface Pageable {
   name: string | null;
   department: string | null;
   page: number;
@@ -9,8 +11,8 @@ interface pageable {
   sort: string;
 }
 
-const useStudentsList = (pageable: pageable) => {
-  return useQuery({
+const useStudentsList = (pageable: Pageable) => {
+  return useQuery<StudentsListResponse>({
     queryKey: ["studentsList", pageable],
     queryFn: () => getStudentsList(pageable),
     enabled: !!pageable,

--- a/src/hooks/student/useStudentMe.ts
+++ b/src/hooks/student/useStudentMe.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import getStudentMe from "@/apis/student/getStudentMe";
+
+const useStudentMe = () => {
+  return useQuery({
+    queryKey: ["studentMe"],
+    queryFn: getStudentMe,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+};
+
+export default useStudentMe;
+

--- a/src/pages/admin/statistic/individual/components/AverageMetrics.tsx
+++ b/src/pages/admin/statistic/individual/components/AverageMetrics.tsx
@@ -7,6 +7,7 @@ interface AverageMetricsProps {
   averageRQ: number;
   averageCQ: number;
   averageTotal: number;
+  showTScore?: boolean;
 }
 
 const containerStyle = css`
@@ -75,84 +76,117 @@ const AverageMetrics: React.FC<AverageMetricsProps> = ({
   averageRQ,
   averageCQ,
   averageTotal,
+  showTScore = false,
 }) => {
   const { data: totalAverageData } = use3qTotalAverage();
 
-  const getComparisonText = (currentValue: number, totalValue: number) => {
-    const difference = currentValue - totalValue;
+  const formatValue = (value: number) =>
+    showTScore ? (Math.round(value * 100) / 100).toFixed(2) : value;
+
+  const getComparisonText = (
+    currentValue: number,
+    baselineValue: number
+  ) => {
+    const difference = currentValue - baselineValue;
     const isPositive = difference >= 0;
     const sign = isPositive ? "+" : "";
     return { text: `${sign}${difference.toFixed(1)}`, isPositive };
+  };
+
+  const tScoreBaseline = {
+    lq: 50 / 3,
+    rq: 50 / 3,
+    cq: 50 / 3,
+    total: 50,
+  };
+
+  const getBaseline = (key: "lq" | "rq" | "cq" | "total") => {
+    if (showTScore) {
+      return tScoreBaseline[key];
+    }
+
+    if (!totalAverageData) return null;
+
+    if (key === "total") {
+      return (
+        totalAverageData.lq +
+        totalAverageData.rq +
+        totalAverageData.cq
+      );
+    }
+
+    return totalAverageData[key];
   };
 
   return (
     <div css={containerStyle}>
       <div css={metricBoxStyle}>
         <div css={metricTitleStyle}>LQ 평균</div>
-        <div css={metricValueStyle("LQ")}>{averageLQ}</div>
-        {totalAverageData && (
-          <div css={comparisonStyle(averageLQ >= totalAverageData.lq)}>
-            전체 평균 대비{" "}
-            <span css={comparisonValueStyle(averageLQ >= totalAverageData.lq)}>
-              {getComparisonText(averageLQ, totalAverageData.lq).text}
-            </span>
-          </div>
-        )}
+        <div css={metricValueStyle("LQ")}>{formatValue(averageLQ)}</div>
+        {(() => {
+          const baseline = getBaseline("lq");
+          if (baseline === null) return null;
+          const isPositive = averageLQ >= baseline;
+          return (
+            <div css={comparisonStyle(isPositive)}>
+              전체 평균 대비{" "}
+              <span css={comparisonValueStyle(isPositive)}>
+                {getComparisonText(averageLQ, baseline).text}
+              </span>
+            </div>
+          );
+        })()}
       </div>
       <div css={metricBoxStyle}>
         <div css={metricTitleStyle}>RQ 평균</div>
-        <div css={metricValueStyle("RQ")}>{averageRQ}</div>
-        {totalAverageData && (
-          <div css={comparisonStyle(averageRQ >= totalAverageData.rq)}>
-            전체 평균 대비{" "}
-            <span css={comparisonValueStyle(averageRQ >= totalAverageData.rq)}>
-              {getComparisonText(averageRQ, totalAverageData.rq).text}
-            </span>
-          </div>
-        )}
+        <div css={metricValueStyle("RQ")}>{formatValue(averageRQ)}</div>
+        {(() => {
+          const baseline = getBaseline("rq");
+          if (baseline === null) return null;
+          const isPositive = averageRQ >= baseline;
+          return (
+            <div css={comparisonStyle(isPositive)}>
+              전체 평균 대비{" "}
+              <span css={comparisonValueStyle(isPositive)}>
+                {getComparisonText(averageRQ, baseline).text}
+              </span>
+            </div>
+          );
+        })()}
       </div>
       <div css={metricBoxStyle}>
         <div css={metricTitleStyle}>CQ 평균</div>
-        <div css={metricValueStyle("CQ")}>{averageCQ}</div>
-        {totalAverageData && (
-          <div css={comparisonStyle(averageCQ >= totalAverageData.cq)}>
-            전체 평균 대비{" "}
-            <span css={comparisonValueStyle(averageCQ >= totalAverageData.cq)}>
-              {getComparisonText(averageCQ, totalAverageData.cq).text}
-            </span>
-          </div>
-        )}
+        <div css={metricValueStyle("CQ")}>{formatValue(averageCQ)}</div>
+        {(() => {
+          const baseline = getBaseline("cq");
+          if (baseline === null) return null;
+          const isPositive = averageCQ >= baseline;
+          return (
+            <div css={comparisonStyle(isPositive)}>
+              전체 평균 대비{" "}
+              <span css={comparisonValueStyle(isPositive)}>
+                {getComparisonText(averageCQ, baseline).text}
+              </span>
+            </div>
+          );
+        })()}
       </div>
       <div css={metricBoxStyle}>
         <div css={metricTitleStyle}>Total 평균</div>
-        <div css={metricValueStyle()}>{averageTotal}</div>
-        {totalAverageData && (
-          <div
-            css={comparisonStyle(
-              averageTotal >=
-                totalAverageData.lq + totalAverageData.rq + totalAverageData.cq
-            )}
-          >
-            전체 평균 대비{" "}
-            <span
-              css={comparisonValueStyle(
-                averageTotal >=
-                  totalAverageData.lq +
-                    totalAverageData.rq +
-                    totalAverageData.cq
-              )}
-            >
-              {
-                getComparisonText(
-                  averageTotal,
-                  totalAverageData.lq +
-                    totalAverageData.rq +
-                    totalAverageData.cq
-                ).text
-              }
-            </span>
-          </div>
-        )}
+        <div css={metricValueStyle()}>{formatValue(averageTotal)}</div>
+        {(() => {
+          const baseline = getBaseline("total");
+          if (baseline === null) return null;
+          const isPositive = averageTotal >= baseline;
+          return (
+            <div css={comparisonStyle(isPositive)}>
+              전체 평균 대비{" "}
+              <span css={comparisonValueStyle(isPositive)}>
+                {getComparisonText(averageTotal, baseline).text}
+              </span>
+            </div>
+          );
+        })()}
       </div>
     </div>
   );

--- a/src/pages/admin/statistic/individual/components/IndividualStudentCard.tsx
+++ b/src/pages/admin/statistic/individual/components/IndividualStudentCard.tsx
@@ -11,6 +11,7 @@ interface StudentCardProps {
   cq?: number;
   onClick?: () => void;
   isSelected?: boolean;
+  showTScore?: boolean;
 }
 
 const cardWrapperStyle = (isSelected: boolean) => css`
@@ -80,7 +81,15 @@ const IndividualStudentCard: React.FC<StudentCardProps> = ({
   cq = 0,
   onClick,
   isSelected = false,
+  showTScore = false,
 }) => {
+  const formatScore = (value: number) => {
+    if (showTScore) {
+      return (Math.round(value * 100) / 100).toFixed(2);
+    }
+    return value.toString();
+  };
+
   return (
     <div css={cardWrapperStyle(isSelected)} onClick={onClick}>
       <div css={infoSectionStyle}>
@@ -90,9 +99,9 @@ const IndividualStudentCard: React.FC<StudentCardProps> = ({
         </span>
       </div>
       <div css={scoreSectionStyle}>
-        <span css={totalScoreStyle}>{totalScore}점</span>
+        <span css={totalScoreStyle}>{formatScore(totalScore)}점</span>
         <span css={qScoreStyle}>
-          LQ:{lq} RQ:{rq} CQ:{cq}
+          LQ:{formatScore(lq)} RQ:{formatScore(rq)} CQ:{formatScore(cq)}
         </span>
       </div>
     </div>

--- a/src/pages/admin/statistic/individual/components/StudentDistributionModal.tsx
+++ b/src/pages/admin/statistic/individual/components/StudentDistributionModal.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { css } from "@emotion/react";
+import Dialog from "@mui/material/Dialog";
+import DialogTitle from "@mui/material/DialogTitle";
+import DialogContent from "@mui/material/DialogContent";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
+import IndividualDistribution from "@/components/graphs/IndividualDistribution";
+import TotalDistribution from "@/components/graphs/TotalDistribution";
+
+interface StudentDistributionModalProps {
+  open: boolean;
+  onClose: () => void;
+  studentName: string;
+  studentId: string;
+  tlq: number;
+  trq: number;
+  tcq: number;
+}
+
+const dialogContentStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 32px;
+  background: #f8f9fa;
+`;
+
+const cardStyle = css`
+  padding: 32px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+`;
+
+const dividerStyle = css`
+  height: 2px;
+  background: linear-gradient(to right, transparent, #e0e0e0, transparent);
+  margin: 16px 0;
+`;
+
+const titleContainerStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const studentInfoStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+const studentNameStyle = css`
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #333;
+`;
+
+const studentIdStyle = css`
+  font-size: 1rem;
+  color: #666;
+`;
+
+const StudentDistributionModal: React.FC<StudentDistributionModalProps> = ({
+  open,
+  onClose,
+  studentName,
+  studentId,
+  tlq,
+  trq,
+  tcq,
+}) => {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="lg"
+      fullWidth
+      PaperProps={{
+        style: {
+          maxHeight: "90vh",
+        },
+      }}
+    >
+      <DialogTitle>
+        <div css={titleContainerStyle}>
+          <div css={studentInfoStyle}>
+            <span css={studentNameStyle}>{studentName} 학생 정규분포 분석</span>
+            <span css={studentIdStyle}>학번: {studentId}</span>
+          </div>
+          <IconButton
+            onClick={onClose}
+            aria-label="닫기"
+            sx={{
+              color: "#666",
+              "&:hover": {
+                color: "#333",
+                background: "#f5f5f5",
+              },
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </div>
+      </DialogTitle>
+      <DialogContent>
+        <div css={dialogContentStyle}>
+          {/* 개별 3Q 지수 분포 */}
+          <div css={cardStyle}>
+            <IndividualDistribution tlq={tlq} trq={trq} tcq={tcq} />
+          </div>
+
+          <div css={dividerStyle} />
+
+          {/* 총 3Q 점수 분포 */}
+          <div css={cardStyle}>
+            <TotalDistribution tlq={tlq} trq={trq} tcq={tcq} />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default StudentDistributionModal;
+

--- a/src/pages/admin/statistic/individual/index.tsx
+++ b/src/pages/admin/statistic/individual/index.tsx
@@ -38,7 +38,6 @@ const chartSectionStyle = css`
 const chartBoxStyle = css`
   flex: 1;
   min-height: 500px;
-  max-height: 600px;
   padding: 20px;
   border: 1px solid #e0e0e0;
   border-radius: 12px;
@@ -47,7 +46,6 @@ const chartBoxStyle = css`
   display: flex;
   flex-direction: column;
   position: relative;
-  overflow: hidden;
 `;
 
 const bottomRowStyle = css`

--- a/src/pages/admin/statistic/individual/index.tsx
+++ b/src/pages/admin/statistic/individual/index.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 import { css } from "@emotion/react";
 import IndividualStudentCard from "./components/IndividualStudentCard";
 import AverageMetrics from "./components/AverageMetrics";
+import StudentDistributionModal from "./components/StudentDistributionModal";
 import useStudentsList, { Pageable } from "@/hooks/admin/useStudentsList";
 import Loading from "@/components/layouts/Loading";
 import Pagination from "@mui/material/Pagination";
@@ -9,6 +10,7 @@ import Box from "@mui/material/Box";
 import { useSelectedUserStore } from "@/stores/selectedUserStore";
 import type { SelectedUser } from "@/stores/selectedUserStore";
 import SimpleBarChart from "@/components/graphs/SimpleBarChart";
+import HorizontalBarChart from "@/components/graphs/HorizontalBarChart";
 import IconButton from "@mui/material/IconButton";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -27,22 +29,25 @@ const containerStyle = css`
 `;
 
 const chartSectionStyle = css`
+  display: flex;
+  gap: 24px;
   width: 100%;
   min-height: 400px;
+`;
+
+const chartBoxStyle = css`
+  flex: 1;
+  min-height: 500px;
+  max-height: 600px;
   padding: 20px;
   border: 1px solid #e0e0e0;
   border-radius: 12px;
   background: white;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-`;
-
-const chartBoxStyle = css`
-  min-height: 350px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
   position: relative;
+  overflow: hidden;
 `;
 
 const bottomRowStyle = css`
@@ -107,6 +112,21 @@ const titleContainerStyle = css`
   display: flex;
   align-items: center;
   gap: 10px;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const titleRowStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const hintTextStyle = css`
+  font-size: 0.85rem;
+  color: #888;
+  font-weight: 400;
+  margin-top: 4px;
 `;
 
 const resetButtonStyle = css`
@@ -200,7 +220,10 @@ const toggleKnobStyle = css`
 const IndividualStatisticLayout = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [chartPage, setChartPage] = useState(0);
+  const [rightChartPage, setRightChartPage] = useState(0);
   const [showTScore, setShowTScore] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [selectedStudent, setSelectedStudent] = useState<SelectedUser | null>(null);
   const studentListRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -222,7 +245,6 @@ const IndividualStatisticLayout = () => {
     clearUsers,
   } = useSelectedUserStore();
 
-  console.log(appliedFilter);
 
   const pageable: Pageable = {
     name: appliedFilter.name,
@@ -236,7 +258,6 @@ const IndividualStatisticLayout = () => {
 
   if (isLoading) return <Loading />;
 
-  console.log(studentsData);
 
   const totalPages = studentsData?.totalPage || 1;
 
@@ -329,6 +350,14 @@ const IndividualStatisticLayout = () => {
     }
   };
 
+  const handleRightChartPageChange = (direction: "prev" | "next") => {
+    if (direction === "prev") {
+      setRightChartPage((prev) => Math.max(0, prev - 1));
+    } else {
+      setRightChartPage((prev) => Math.min(3, prev + 1));
+    }
+  };
+
   const getCurrentChartData = () => {
     if (selectedUsers.length === 0) return null;
 
@@ -352,7 +381,81 @@ const IndividualStatisticLayout = () => {
   const handleReset = () => {
     clearUsers();
     setChartPage(0);
+    setRightChartPage(0);
   };
+
+  // 우측 가로 막대 그래프 데이터 생성
+  const createHorizontalBarChartData = () => {
+    if (selectedUsers.length === 0) return [];
+
+    // 점수순으로 정렬 (높은 점수가 위로)
+    const sortedUsers = [...selectedUsers].sort((a, b) => {
+      if (showTScore) {
+        const totalA = a.totalTScore || 0;
+        const totalB = b.totalTScore || 0;
+        return totalB - totalA;
+      } else {
+        const totalA = a.totalScore || 0;
+        const totalB = b.totalScore || 0;
+        return totalB - totalA;
+      }
+    });
+
+    if (rightChartPage === 0) {
+      // 누적 막대 (3Q 전체) - 총합으로 표시
+      const data = sortedUsers.map((user) => {
+        let totalValue;
+        
+        if (showTScore) {
+          const lq = typeof user.tlq === 'number' && !isNaN(user.tlq) ? user.tlq : 0;
+          const rq = typeof user.trq === 'number' && !isNaN(user.trq) ? user.trq : 0;
+          const cq = typeof user.tcq === 'number' && !isNaN(user.tcq) ? user.tcq : 0;
+          totalValue = lq + rq + cq;
+        } else {
+          const lq = typeof user.lq === 'number' && !isNaN(user.lq) ? user.lq : 0;
+          const rq = typeof user.rq === 'number' && !isNaN(user.rq) ? user.rq : 0;
+          const cq = typeof user.cq === 'number' && !isNaN(user.cq) ? user.cq : 0;
+          totalValue = lq + rq + cq;
+        }
+        
+        return {
+          name: user.name,
+          value: totalValue,
+        };
+      });
+      return data;
+    } else {
+      // 개별 영역 (LQ, RQ, CQ)
+      const categories = ["LQ", "RQ", "CQ"] as const;
+      const category = categories[rightChartPage - 1];
+      
+      return sortedUsers.map((user) => {
+        let value = 0;
+        if (showTScore) {
+          if (category === "LQ") value = user.tlq || 0;
+          else if (category === "RQ") value = user.trq || 0;
+          else if (category === "CQ") value = user.tcq || 0;
+        } else {
+          if (category === "LQ") value = user.lq || 0;
+          else if (category === "RQ") value = user.rq || 0;
+          else if (category === "CQ") value = user.cq || 0;
+        }
+        return {
+          name: user.name,
+          value: typeof value === 'number' && !isNaN(value) ? value : 0,
+        };
+      });
+    }
+  };
+
+  const getRightChartTitle = () => {
+    if (rightChartPage === 0) return "전체 학생 3Q 분포";
+    const categories = ["LQ", "RQ", "CQ"];
+    return `전체 학생 ${categories[rightChartPage - 1]} 분포`;
+  };
+
+  const horizontalChartData = createHorizontalBarChartData();
+  const rightChartTitle = getRightChartTitle();
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -363,6 +466,16 @@ const IndividualStatisticLayout = () => {
         block: "start",
       });
     }
+  };
+
+  const handleStudentClick = (user: SelectedUser) => {
+    setSelectedStudent(user);
+    setModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setModalOpen(false);
+    setSelectedStudent(null);
   };
 
   return (
@@ -392,18 +505,15 @@ const IndividualStatisticLayout = () => {
         showTScore={showTScore}
       />
 
-      {/* 그래프 섹션 - 메인 */}
+      {/* 그래프 섹션 - 좌우 분할 */}
       <div css={chartSectionStyle}>
+        {/* 좌측: 세로 막대 그래프 */}
         {selectedUsers.length === 0 ? (
           <div css={chartBoxStyle}>
             <div css={noDataStyle}>선택된 학생이 없습니다</div>
           </div>
         ) : (
-          <div css={css`
-            ${chartBoxStyle}
-            justify-content: flex-start;
-            align-items: stretch;
-          `}>
+          <div css={chartBoxStyle}>
             <div css={navigationButtonsStyle}>
               <IconButton
                 size="small"
@@ -423,13 +533,55 @@ const IndividualStatisticLayout = () => {
                 <ChevronRightIcon />
               </IconButton>
             </div>
-            {currentChartData && (
+            <div style={{ flex: 1, width: "100%", display: "flex", flexDirection: "column" }}>
+              {currentChartData && (
                 <SimpleBarChart
                   data={currentChartData.data}
                   title={currentChartData.title}
                   showTScore={showTScore}
                 />
-            )}
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* 우측: 가로 막대 그래프 */}
+        {selectedUsers.length === 0 ? (
+          <div css={chartBoxStyle}>
+            <div css={noDataStyle}>선택된 학생이 없습니다</div>
+          </div>
+        ) : (
+          <div css={chartBoxStyle}>
+            <div css={navigationButtonsStyle}>
+              <IconButton
+                size="small"
+                onClick={() => handleRightChartPageChange("prev")}
+                disabled={rightChartPage === 0}
+              >
+                <ChevronLeftIcon />
+              </IconButton>
+              <div css={pageIndicatorStyle}>
+                {rightChartPage + 1}/4
+              </div>
+              <IconButton
+                size="small"
+                onClick={() => handleRightChartPageChange("next")}
+                disabled={rightChartPage === 3}
+              >
+                <ChevronRightIcon />
+              </IconButton>
+            </div>
+            <div style={{ flex: 1, width: "100%", display: "flex", flexDirection: "column", overflow: "auto" }}>
+              <HorizontalBarChart
+                data={horizontalChartData}
+                title={rightChartTitle}
+                showStacked={rightChartPage === 0}
+                singleCategory={
+                  rightChartPage === 1 ? "LQ" : rightChartPage === 2 ? "RQ" : rightChartPage === 3 ? "CQ" : undefined
+                }
+                showTScore={showTScore}
+              />
+            </div>
           </div>
         )}
       </div>
@@ -501,26 +653,43 @@ const IndividualStatisticLayout = () => {
         <div css={rightBoxStyle}>
           <div css={selectedUserTitleStyle}>
             <div css={titleContainerStyle}>
-              <span>선택된 학생 목록</span>
-              {selectedUsers.length > 0 && (
-                <IconButton
-                  size="small"
-                  onClick={handleReset}
-                  css={resetButtonStyle}
-                  title="초기화"
-                >
-                  <RefreshIcon />
-                </IconButton>
-              )}
+              <div css={titleRowStyle}>
+                <span>선택된 학생 목록</span>
+                {selectedUsers.length > 0 && (
+                  <IconButton
+                    size="small"
+                    onClick={handleReset}
+                    css={resetButtonStyle}
+                    title="초기화"
+                  >
+                    <RefreshIcon />
+                  </IconButton>
+                )}
+              </div>
+              <span css={hintTextStyle}>아래 학생을 클릭하면 개인별 점수 정보를 확인할 수 있습니다</span>
             </div>
           </div>
           <SelectedUsersTable 
             users={selectedUsers} 
             onUserRemove={removeUser}
             showTScore={showTScore}
+            onUserClick={handleStudentClick}
           />
         </div>
       </div>
+
+      {/* 학생 정규분포 모달 */}
+      {selectedStudent && (
+        <StudentDistributionModal
+          open={modalOpen}
+          onClose={handleModalClose}
+          studentName={selectedStudent.name}
+          studentId={selectedStudent.studentId}
+          tlq={selectedStudent.tlq || 0}
+          trq={selectedStudent.trq || 0}
+          tcq={selectedStudent.tcq || 0}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/admin/statistic/individual/index.tsx
+++ b/src/pages/admin/statistic/individual/index.tsx
@@ -388,16 +388,34 @@ const IndividualStatisticLayout = () => {
   const createHorizontalBarChartData = () => {
     if (selectedUsers.length === 0) return [];
 
-    // 점수순으로 정렬 (높은 점수가 위로)
+    // rightChartPage에 따라 정렬 기준 변경 (높은 점수가 위로)
     const sortedUsers = [...selectedUsers].sort((a, b) => {
-      if (showTScore) {
-        const totalA = a.totalTScore || 0;
-        const totalB = b.totalTScore || 0;
-        return totalB - totalA;
+      if (rightChartPage === 0) {
+        // 전체 3Q 총합 기준 정렬
+        if (showTScore) {
+          const totalA = (a.tlq || 0) + (a.trq || 0) + (a.tcq || 0);
+          const totalB = (b.tlq || 0) + (b.trq || 0) + (b.tcq || 0);
+          return totalB - totalA;
+        } else {
+          const totalA = (a.lq || 0) + (a.rq || 0) + (a.cq || 0);
+          const totalB = (b.lq || 0) + (b.rq || 0) + (b.cq || 0);
+          return totalB - totalA;
+        }
+      } else if (rightChartPage === 1) {
+        // LQ 기준 정렬
+        const valueA = showTScore ? (a.tlq || 0) : (a.lq || 0);
+        const valueB = showTScore ? (b.tlq || 0) : (b.lq || 0);
+        return valueB - valueA;
+      } else if (rightChartPage === 2) {
+        // RQ 기준 정렬
+        const valueA = showTScore ? (a.trq || 0) : (a.rq || 0);
+        const valueB = showTScore ? (b.trq || 0) : (b.rq || 0);
+        return valueB - valueA;
       } else {
-        const totalA = a.totalScore || 0;
-        const totalB = b.totalScore || 0;
-        return totalB - totalA;
+        // CQ 기준 정렬
+        const valueA = showTScore ? (a.tcq || 0) : (a.cq || 0);
+        const valueB = showTScore ? (b.tcq || 0) : (b.cq || 0);
+        return valueB - valueA;
       }
     });
 

--- a/src/pages/admin/statistic/individual/index.tsx
+++ b/src/pages/admin/statistic/individual/index.tsx
@@ -2,11 +2,12 @@ import { useState, useRef } from "react";
 import { css } from "@emotion/react";
 import IndividualStudentCard from "./components/IndividualStudentCard";
 import AverageMetrics from "./components/AverageMetrics";
-import useStudentsList from "@/hooks/admin/useStudentsList";
+import useStudentsList, { Pageable } from "@/hooks/admin/useStudentsList";
 import Loading from "@/components/layouts/Loading";
 import Pagination from "@mui/material/Pagination";
 import Box from "@mui/material/Box";
 import { useSelectedUserStore } from "@/stores/selectedUserStore";
+import type { SelectedUser } from "@/stores/selectedUserStore";
 import SimpleBarChart from "@/components/graphs/SimpleBarChart";
 import IconButton from "@mui/material/IconButton";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
@@ -16,45 +17,62 @@ import SelectedUsersTable from "@/components/table/SelectedUsersTable";
 import useFilter from "@/hooks/filter/useFilter";
 import { adminStudentListFilterConfig } from "@/components/filter/filterConfig";
 import GenericFilter from "@/components/filter/GenericFilter";
+import type { AdminStudentResponseItem } from "@/apis/admin/getStudentsList";
 
 const containerStyle = css`
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const chartSectionStyle = css`
+  width: 100%;
+  min-height: 400px;
+  padding: 20px;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+`;
+
+const chartBoxStyle = css`
+  min-height: 350px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
 `;
 
 const bottomRowStyle = css`
   display: flex;
   gap: 24px;
+  width: 100%;
 `;
 
 const leftBoxStyle = css`
-  flex: 3;
-  padding: 10px 20px;
+  flex: 1;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-`;
-
-const rightColStyle = css`
-  flex: 4;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 `;
 
 const rightBoxStyle = css`
-  min-height: 180px;
+  flex: 1;
+  min-height: 400px;
   display: flex;
   flex-direction: column;
-  padding: 15px;
+  padding: 20px;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   overflow-y: auto;
-  position: relative;
-`;
-
-const chartBoxStyle = css`
-  min-height: 180px;
-  display: flex;
-  flex-direction: column;
-  padding: 15px;
-  position: relative;
 `;
 
 const navigationButtonsStyle = css`
@@ -103,20 +121,86 @@ const userListStyle = css`
   flex-direction: column;
   gap: 6px;
   margin-bottom: 20px;
+  
+  h2 {
+    font-size: 1.3rem;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: #333;
+  }
 `;
 
 const noDataStyle = css`
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  gap: 12px;
+  color: #999;
+  font-size: 1.2rem;
+  font-weight: 500;
+  text-align: center;
+  padding: 40px;
+`;
+
+const headerStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+`;
+
+const toggleContainerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const toggleLabelStyle = css`
+  font-size: 0.9rem;
   color: #666;
-  font-style: italic;
+  font-weight: 500;
+`;
+
+const toggleButtonStyle = css`
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: #e0e0e0;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.3s;
+  
+  &:hover {
+    background: #d0d0d0;
+  }
+  
+  &.active {
+    background: #4CAF50;
+  }
+`;
+
+const toggleKnobStyle = css`
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.3s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  
+  &.active {
+    transform: translateX(20px);
+  }
 `;
 
 const IndividualStatisticLayout = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [chartPage, setChartPage] = useState(0);
+  const [showTScore, setShowTScore] = useState(false);
   const studentListRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -140,7 +224,7 @@ const IndividualStatisticLayout = () => {
 
   console.log(appliedFilter);
 
-  const pageable = {
+  const pageable: Pageable = {
     name: appliedFilter.name,
     department: appliedFilter.department,
     page: currentPage - 1, // API는 0-based pagination을 사용
@@ -156,20 +240,65 @@ const IndividualStatisticLayout = () => {
 
   const totalPages = studentsData?.totalPage || 1;
 
-  const createBarChartData = (user: any) => ({
-    LQ: user.lq || 0,
-    RQ: user.rq || 0,
-    CQ: user.cq || 0,
-  });
+  // T-점수 안전하게 파싱 (NaN 처리)
+  const parseTScore = (value: unknown): number => {
+    if (value === "NaN" || value === null || value === undefined) return 0;
+    const num =
+      typeof value === "string"
+        ? parseFloat(value)
+        : typeof value === "number"
+        ? value
+        : Number(value);
+    return isNaN(num) ? 0 : num;
+  };
+
+  // T-점수 합계 계산
+  const calculateTotalTScore = (
+    tlq: unknown,
+    trq: unknown,
+    tcq: unknown
+  ): number => {
+    return parseTScore(tlq) + parseTScore(trq) + parseTScore(tcq);
+  };
+
+  type ChartUser = AdminStudentResponseItem | SelectedUser;
+
+  const createBarChartData = (user: ChartUser) => {
+    if (showTScore) {
+      const totalT = calculateTotalTScore(user.tlq, user.trq, user.tcq);
+      return {
+        LQ: parseTScore(user.tlq),
+        RQ: parseTScore(user.trq),
+        CQ: parseTScore(user.tcq),
+        "T-합계": totalT,
+      };
+    }
+    return {
+      LQ: user.lq || 0,
+      RQ: user.rq || 0,
+      CQ: user.cq || 0,
+    };
+  };
 
   // 평균값으로 Bar Chart 데이터 생성
-  const createAverageBarChartData = () => ({
-    LQ: averages.averageLQ,
-    RQ: averages.averageRQ,
-    CQ: averages.averageCQ,
-  });
+  const createAverageBarChartData = () => {
+    if (showTScore) {
+      const avgTotal = averages.averageTLQ + averages.averageTRQ + averages.averageTCQ;
+      return {
+        LQ: averages.averageTLQ,
+        RQ: averages.averageTRQ,
+        CQ: averages.averageTCQ,
+        "T-합계": avgTotal,
+      };
+    }
+    return {
+      LQ: averages.averageLQ,
+      RQ: averages.averageRQ,
+      CQ: averages.averageCQ,
+    };
+  };
 
-  const handleUserClick = (student: any) => {
+  const handleUserClick = (student: AdminStudentResponseItem) => {
     const userData = {
       id: student.id,
       name: student.name,
@@ -179,6 +308,10 @@ const IndividualStatisticLayout = () => {
       rq: student.rq || 0,
       cq: student.cq || 0,
       totalScore: student.totalScore || 0,
+      tlq: parseTScore(student.tlq),
+      trq: parseTScore(student.trq),
+      tcq: parseTScore(student.tcq),
+      totalTScore: calculateTotalTScore(student.tlq, student.trq, student.tcq),
     };
 
     if (isUserSelected(student.id)) {
@@ -234,14 +367,76 @@ const IndividualStatisticLayout = () => {
 
   return (
     <div css={containerStyle}>
-      <h1>개인별 통계 비교</h1>
+      <div css={headerStyle}>
+        <h1 style={{ margin: 0 }}>개인별 통계 비교</h1>
+        <div css={toggleContainerStyle}>
+          <span css={toggleLabelStyle}>T-점수 보기</span>
+          <button
+            css={toggleButtonStyle}
+            className={showTScore ? "active" : ""}
+            onClick={() => setShowTScore(!showTScore)}
+            aria-label="T-점수 보기 토글"
+          >
+            <div css={toggleKnobStyle} className={showTScore ? "active" : ""} />
+          </button>
+        </div>
+      </div>
       <AverageMetrics
-        averageLQ={averages.averageLQ}
-        averageRQ={averages.averageRQ}
-        averageCQ={averages.averageCQ}
-        averageTotal={averages.averageTotal}
+        averageLQ={showTScore ? averages.averageTLQ : averages.averageLQ}
+        averageRQ={showTScore ? averages.averageTRQ : averages.averageRQ}
+        averageCQ={showTScore ? averages.averageTCQ : averages.averageCQ}
+        averageTotal={showTScore 
+          ? averages.averageTLQ + averages.averageTRQ + averages.averageTCQ
+          : averages.averageTotal
+        }
+        showTScore={showTScore}
       />
+
+      {/* 그래프 섹션 - 메인 */}
+      <div css={chartSectionStyle}>
+        {selectedUsers.length === 0 ? (
+          <div css={chartBoxStyle}>
+            <div css={noDataStyle}>선택된 학생이 없습니다</div>
+          </div>
+        ) : (
+          <div css={css`
+            ${chartBoxStyle}
+            justify-content: flex-start;
+            align-items: stretch;
+          `}>
+            <div css={navigationButtonsStyle}>
+              <IconButton
+                size="small"
+                onClick={() => handleChartPageChange("prev")}
+                disabled={chartPage === 0}
+              >
+                <ChevronLeftIcon />
+              </IconButton>
+              <div css={pageIndicatorStyle}>
+                {chartPage + 1}/{totalChartPages}
+              </div>
+              <IconButton
+                size="small"
+                onClick={() => handleChartPageChange("next")}
+                disabled={chartPage === totalChartPages - 1}
+              >
+                <ChevronRightIcon />
+              </IconButton>
+            </div>
+            {currentChartData && (
+                <SimpleBarChart
+                  data={currentChartData.data}
+                  title={currentChartData.title}
+                  showTScore={showTScore}
+                />
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 학생 목록 섹션 - 하단 좌우 배치 */}
       <div css={bottomRowStyle}>
+        {/* 전체 학생 목록 - 좌측 */}
         <div css={leftBoxStyle}>
           <div css={userListStyle} ref={studentListRef}>
             <h2>전체 학생 목록</h2>
@@ -259,21 +454,25 @@ const IndividualStatisticLayout = () => {
               filterShow={false}
             />
 
-            {studentsData?.content?.length === 0 ? (
+            {(studentsData?.content?.length ?? 0) === 0 ? (
               <div>학생이 없습니다.</div>
             ) : (
-              studentsData?.content?.map((student: any) => (
+              (studentsData?.content ?? []).map((student) => (
                 <IndividualStudentCard
                   key={student.id}
                   name={student.name}
                   studentId={student.studentId}
                   department={student.department}
-                  totalScore={student.totalScore || 0}
-                  lq={student.lq || 0}
-                  rq={student.rq || 0}
-                  cq={student.cq || 0}
+                  totalScore={showTScore 
+                    ? calculateTotalTScore(student.tlq, student.trq, student.tcq)
+                    : (student.totalScore || 0)
+                  }
+                  lq={showTScore ? parseTScore(student.tlq) : (student.lq || 0)}
+                  rq={showTScore ? parseTScore(student.trq) : (student.rq || 0)}
+                  cq={showTScore ? parseTScore(student.tcq) : (student.cq || 0)}
                   onClick={() => handleUserClick(student)}
                   isSelected={isUserSelected(student.id)}
+                  showTScore={showTScore}
                 />
               ))
             )}
@@ -297,61 +496,29 @@ const IndividualStatisticLayout = () => {
             />
           </Box>
         </div>
-        <div css={rightColStyle}>
-          <div css={chartBoxStyle}>
-            {selectedUsers.length === 0 ? (
-              <div css={noDataStyle}>선택된 학생이 없습니다</div>
-            ) : (
-              <>
-                <div css={navigationButtonsStyle}>
-                  <IconButton
-                    size="small"
-                    onClick={() => handleChartPageChange("prev")}
-                    disabled={chartPage === 0}
-                  >
-                    <ChevronLeftIcon />
-                  </IconButton>
-                  <div css={pageIndicatorStyle}>
-                    {chartPage + 1}/{totalChartPages}
-                  </div>
-                  <IconButton
-                    size="small"
-                    onClick={() => handleChartPageChange("next")}
-                    disabled={chartPage === totalChartPages - 1}
-                  >
-                    <ChevronRightIcon />
-                  </IconButton>
-                </div>
-                {currentChartData && (
-                  <SimpleBarChart
-                    data={currentChartData.data}
-                    title={currentChartData.title}
-                  />
-                )}
-              </>
-            )}
-          </div>
-          <div css={rightBoxStyle}>
-            <div css={selectedUserTitleStyle}>
-              <div css={titleContainerStyle}>
-                <span>선택된 학생 목록</span>
-                {selectedUsers.length > 0 && (
-                  <IconButton
-                    size="small"
-                    onClick={handleReset}
-                    css={resetButtonStyle}
-                    title="초기화"
-                  >
-                    <RefreshIcon />
-                  </IconButton>
-                )}
-              </div>
+
+        {/* 선택된 학생 목록 - 우측 */}
+        <div css={rightBoxStyle}>
+          <div css={selectedUserTitleStyle}>
+            <div css={titleContainerStyle}>
+              <span>선택된 학생 목록</span>
+              {selectedUsers.length > 0 && (
+                <IconButton
+                  size="small"
+                  onClick={handleReset}
+                  css={resetButtonStyle}
+                  title="초기화"
+                >
+                  <RefreshIcon />
+                </IconButton>
+              )}
             </div>
-            <SelectedUsersTable
-              users={selectedUsers}
-              onUserRemove={removeUser}
-            />
           </div>
+          <SelectedUsersTable 
+            users={selectedUsers} 
+            onUserRemove={removeUser}
+            showTScore={showTScore}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/student/dashboard/components/QCardVertical.tsx
+++ b/src/pages/student/dashboard/components/QCardVertical.tsx
@@ -6,10 +6,23 @@ interface QCardVerticalProps {
   category: "LQ" | "RQ" | "CQ";
   description: string;
   score: number;
-  percentage: number;
+  tScore: number; // T-점수 (상위 퍼센티지 계산용, 토글과 무관)
   average: number;
   onViewAll?: () => void;
 }
+
+// T-점수 기반 백분위 계산 함수 (IndividualDistribution과 동일)
+const calculatePercentile = (value: number, mean: number, stdDev: number): number => {
+  const z = (value - mean) / stdDev;
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989423 * Math.exp((-z * z) / 2);
+  const probability =
+    d *
+    t *
+    (0.3193815 +
+      t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+  return z >= 0 ? (1 - probability) * 100 : probability * 100;
+};
 
 const cardStyle = css`
   border-radius: 12px;
@@ -122,10 +135,19 @@ const QCardVertical: React.FC<QCardVerticalProps> = ({
   category,
   description,
   score,
-  percentage,
+  tScore,
   average,
   onViewAll,
 }) => {
+  // T-점수 기반 상위 퍼센티지 계산 (토글과 무관하게 항상 T-점수 기준)
+  // T-점수는 3개 영역 합이 평균 50이 되도록 설계
+  // 따라서 각 영역의 평균은 50/3 ≈ 16.67
+  const mean = 50 / 3;
+  const stdDev = 10;
+  
+  const percentile = calculatePercentile(tScore, mean, stdDev);
+  const topPercentage = Math.max(0, Math.min(100, 100 - percentile));
+  
   return (
     <div css={cardStyle}>
       <div css={topSection}>
@@ -147,9 +169,9 @@ const QCardVertical: React.FC<QCardVerticalProps> = ({
       </div>
       <div css={barSection}>
         <div css={barContainerStyle}>
-          <div css={barStyle(100 - percentage)} />
+          <div css={barStyle(topPercentage)} />
         </div>
-        <span css={percentTextStyle}>상위 {percentage}%</span>
+        <span css={percentTextStyle}>상위 {topPercentage.toFixed(1)}%</span>
       </div>
       <div css={bottomSection}>학과 평균: {average}점</div>
     </div>

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -259,9 +259,9 @@ const StudentDashboard: React.FC = () => {
         title="성과 분석"
         type="block"
         options={{
-          labels: ["연도별 변화 추이", "지수별 분석", "학과별 비교"],
+          labels: ["월별 변화 추이", "지수별 분석", "학과별 비교"],
           datasets: {
-            "연도별 변화 추이": <LineChart data={lineChartData} />,
+            "월별 변화 추이": <LineChart data={lineChartData} />,
             "지수별 분석": <QuotientChart data={totalData} />,
             "학과별 비교": <StackedBarChart data={totalData} />,
           },

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -5,12 +5,14 @@ import GraphWrapper from "@/components/graphs/GraphWrapper";
 import LineChart from "@/components/graphs/LineChart";
 import StackedBarChart from "@/components/graphs/StackedBarChart";
 import QuotientChart from "@/components/graphs/QuotientChart";
+import MyDistribution from "@/components/graphs/MyDistribution";
 import ActivityPreviewItem from "./components/ActivityPreviwItem";
 import ApprovedActivitiesModal from "./components/ApprovedActivitiesModal";
 import useStudent3qInfo from "@/hooks/student/useStudent3qInfo";
 import useStudent3qChange from "@/hooks/student/useStudent3qChange";
 import useStudent3qAverages from "@/hooks/student/useStudent3qAverages";
 import useStudentActivityList from "@/hooks/student/useStudentActivityList";
+import useStudentMe from "@/hooks/student/useStudentMe";
 import Loading from "@/components/layouts/Loading";
 import { useNavigate } from "react-router-dom";
 
@@ -105,11 +107,15 @@ const StudentDashboard: React.FC = () => {
       sort: "desc",
     });
 
+  // 학생 프로필 정보 (T-점수 포함)
+  const { data: studentMe, isLoading: studentMeLoading } = useStudentMe();
+
   if (
     student3qInfoLoading ||
     student3qChangeLoading ||
     student3qAveragesLoading ||
-    studentActivityListLoading
+    studentActivityListLoading ||
+    studentMeLoading
   ) {
     return <Loading />;
   }
@@ -259,8 +265,17 @@ const StudentDashboard: React.FC = () => {
         title="성과 분석"
         type="block"
         options={{
-          labels: ["월별 변화 추이", "지수별 분석", "학과별 비교"],
+          labels: ["나의 분포", "월별 변화 추이", "지수별 분석", "학과별 비교"],
           datasets: {
+            "나의 분포": studentMe ? (
+              <MyDistribution
+                tlq={studentMe.tlq}
+                trq={studentMe.trq}
+                tcq={studentMe.tcq}
+              />
+            ) : (
+              <div>데이터를 불러올 수 없습니다.</div>
+            ),
             "월별 변화 추이": <LineChart data={lineChartData} />,
             "지수별 분석": <QuotientChart data={totalData} />,
             "학과별 비교": <StackedBarChart data={totalData} />,

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -191,24 +191,24 @@ const StudentDashboard: React.FC = () => {
           category: "LQ" as "LQ" | "RQ" | "CQ",
           description: "학습 능력 지수 (T-점수)",
           score: Math.round((studentMe?.tlq ?? 0) * 100) / 100,
+          tScore: Math.round((studentMe?.tlq ?? 0) * 100) / 100,
           average: Math.round((50 / 3) * 100) / 100, // 16.67
-          percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
         },
         {
           title: "Research Quotient (RQ)",
           category: "RQ" as "LQ" | "RQ" | "CQ",
           description: "연구 능력 지수 (T-점수)",
           score: Math.round((studentMe?.trq ?? 0) * 100) / 100,
+          tScore: Math.round((studentMe?.trq ?? 0) * 100) / 100,
           average: Math.round((50 / 3) * 100) / 100, // 16.67
-          percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
         },
         {
           title: "Creative Quotient (CQ)",
           category: "CQ" as "LQ" | "RQ" | "CQ",
           description: "교류 능력 지수 (T-점수)",
           score: Math.round((studentMe?.tcq ?? 0) * 100) / 100,
+          tScore: Math.round((studentMe?.tcq ?? 0) * 100) / 100,
           average: Math.round((50 / 3) * 100) / 100, // 16.67
-          percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
         },
       ]
     : [
@@ -217,24 +217,24 @@ const StudentDashboard: React.FC = () => {
       category: "LQ" as "LQ" | "RQ" | "CQ",
       description: "학습 능력 지수",
       score: Math.round((student3qInfo?.lq.score ?? 0) * 100) / 100,
+      tScore: Math.round((studentMe?.tlq ?? 0) * 100) / 100,
       average: Math.round((student3qInfo?.lq.average ?? 0) * 100) / 100,
-      percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
     },
     {
       title: "Research Quotient (RQ)",
       category: "RQ" as "LQ" | "RQ" | "CQ",
       description: "연구 능력 지수",
       score: Math.round((student3qInfo?.rq.score ?? 0) * 100) / 100,
+      tScore: Math.round((studentMe?.trq ?? 0) * 100) / 100,
       average: Math.round((student3qInfo?.rq.average ?? 0) * 100) / 100,
-      percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
     },
     {
       title: "Creative Quotient (CQ)",
       category: "CQ" as "LQ" | "RQ" | "CQ",
       description: "교류 능력 지수",
       score: Math.round((student3qInfo?.cq.score ?? 0) * 100) / 100,
+      tScore: Math.round((studentMe?.tcq ?? 0) * 100) / 100,
       average: Math.round((student3qInfo?.cq.average ?? 0) * 100) / 100,
-      percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
     },
   ];
 
@@ -320,7 +320,7 @@ const StudentDashboard: React.FC = () => {
               category={q.category}
               description={q.description}
               score={q.score}
-              percentage={q.percentage}
+              tScore={q.tScore}
               average={q.average}
               onViewAll={() => setSelectedCategory(q.category)}
             />

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -43,6 +43,7 @@ const subtitleStyle = css`
   font-size: 1.5rem;
   font-weight: bold;
   margin-bottom: 0;
+  margin-top: 0;
 `;
 
 const summaryContainerStyle = css`
@@ -79,9 +80,64 @@ const buttonContainerStyle = css`
   width: 100%;
 `;
 
+const sectionHeaderStyle = css`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
+
+const toggleContainerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const toggleLabelStyle = css`
+  font-size: 0.9rem;
+  color: #666;
+  font-weight: 500;
+`;
+
+const toggleButtonStyle = css`
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background: #e0e0e0;
+  border-radius: 12px;
+  border: none;
+  cursor: pointer;
+  transition: background 0.3s;
+  
+  &:hover {
+    background: #d0d0d0;
+  }
+  
+  &.active {
+    background: #4CAF50;
+  }
+`;
+
+const toggleKnobStyle = css`
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.3s;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  
+  &.active {
+    transform: translateX(20px);
+  }
+`;
+
 const StudentDashboard: React.FC = () => {
   const navigate = useNavigate();
   const [selectedCategory, setSelectedCategory] = useState<"LQ" | "RQ" | "CQ" | null>(null);
+  const [showTScore, setShowTScore] = useState(false);
   
   const { data: student3qInfo, isLoading: student3qInfoLoading } =
     useStudent3qInfo();
@@ -127,33 +183,60 @@ const StudentDashboard: React.FC = () => {
       ) || []
     : [];
 
-  // 3Q 통계 데이터
-  const QData = [
-    {
-      title: "Learning Quotient (LQ)",
-      category: "LQ" as "LQ" | "RQ" | "CQ",
-      description: "학습 능력 지수",
-      score: Math.round((student3qInfo?.lq.score ?? 0) * 100) / 100,
-      average: Math.round((student3qInfo?.lq.average ?? 0) * 100) / 100,
-      percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
-    },
-    {
-      title: "Research Quotient (RQ)",
-      category: "RQ" as "LQ" | "RQ" | "CQ",
-      description: "연구 능력 지수",
-      score: Math.round((student3qInfo?.rq.score ?? 0) * 100) / 100,
-      average: Math.round((student3qInfo?.rq.average ?? 0) * 100) / 100,
-      percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
-    },
-    {
-      title: "Creative Quotient (CQ)",
-      category: "CQ" as "LQ" | "RQ" | "CQ",
-      description: "교류 능력 지수",
-      score: Math.round((student3qInfo?.cq.score ?? 0) * 100) / 100,
-      average: Math.round((student3qInfo?.cq.average ?? 0) * 100) / 100,
-      percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
-    },
-  ];
+  // 3Q 통계 데이터 (일반 점수 또는 T-점수)
+  const QData = showTScore
+    ? [
+        {
+          title: "Learning Quotient (LQ)",
+          category: "LQ" as "LQ" | "RQ" | "CQ",
+          description: "학습 능력 지수 (T-점수)",
+          score: Math.round((studentMe?.tlq ?? 0) * 100) / 100,
+          average: Math.round((50 / 3) * 100) / 100, // 16.67
+          percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
+        },
+        {
+          title: "Research Quotient (RQ)",
+          category: "RQ" as "LQ" | "RQ" | "CQ",
+          description: "연구 능력 지수 (T-점수)",
+          score: Math.round((studentMe?.trq ?? 0) * 100) / 100,
+          average: Math.round((50 / 3) * 100) / 100, // 16.67
+          percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
+        },
+        {
+          title: "Creative Quotient (CQ)",
+          category: "CQ" as "LQ" | "RQ" | "CQ",
+          description: "교류 능력 지수 (T-점수)",
+          score: Math.round((studentMe?.tcq ?? 0) * 100) / 100,
+          average: Math.round((50 / 3) * 100) / 100, // 16.67
+          percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
+        },
+      ]
+    : [
+        {
+          title: "Learning Quotient (LQ)",
+          category: "LQ" as "LQ" | "RQ" | "CQ",
+          description: "학습 능력 지수",
+          score: Math.round((student3qInfo?.lq.score ?? 0) * 100) / 100,
+          average: Math.round((student3qInfo?.lq.average ?? 0) * 100) / 100,
+          percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
+        },
+        {
+          title: "Research Quotient (RQ)",
+          category: "RQ" as "LQ" | "RQ" | "CQ",
+          description: "연구 능력 지수",
+          score: Math.round((student3qInfo?.rq.score ?? 0) * 100) / 100,
+          average: Math.round((student3qInfo?.rq.average ?? 0) * 100) / 100,
+          percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
+        },
+        {
+          title: "Creative Quotient (CQ)",
+          category: "CQ" as "LQ" | "RQ" | "CQ",
+          description: "교류 능력 지수",
+          score: Math.round((student3qInfo?.cq.score ?? 0) * 100) / 100,
+          average: Math.round((student3qInfo?.cq.average ?? 0) * 100) / 100,
+          percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
+        },
+      ];
 
   // 3Q 변화 데이터
   const lineChartData =
@@ -216,7 +299,20 @@ const StudentDashboard: React.FC = () => {
       <div css={summaryContainerStyle}>
         {/* 3Q 통계 */}
         <div css={{ width: "100%" }}>
-          <h2 css={subtitleStyle}>3Q 지표 요약</h2>
+          <div css={sectionHeaderStyle}>
+            <h2 css={subtitleStyle}>3Q 지표 요약</h2>
+            <div css={toggleContainerStyle}>
+              <span css={toggleLabelStyle}>T-점수 보기</span>
+              <button
+                css={toggleButtonStyle}
+                className={showTScore ? "active" : ""}
+                onClick={() => setShowTScore(!showTScore)}
+                aria-label="T-점수 보기 토글"
+              >
+                <div css={toggleKnobStyle} className={showTScore ? "active" : ""} />
+              </button>
+            </div>
+          </div>
           {QData.map((q) => (
             <QCardVertical
               key={q.title}

--- a/src/pages/student/dashboard/index.tsx
+++ b/src/pages/student/dashboard/index.tsx
@@ -212,31 +212,31 @@ const StudentDashboard: React.FC = () => {
         },
       ]
     : [
-        {
-          title: "Learning Quotient (LQ)",
-          category: "LQ" as "LQ" | "RQ" | "CQ",
-          description: "학습 능력 지수",
-          score: Math.round((student3qInfo?.lq.score ?? 0) * 100) / 100,
-          average: Math.round((student3qInfo?.lq.average ?? 0) * 100) / 100,
-          percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
-        },
-        {
-          title: "Research Quotient (RQ)",
-          category: "RQ" as "LQ" | "RQ" | "CQ",
-          description: "연구 능력 지수",
-          score: Math.round((student3qInfo?.rq.score ?? 0) * 100) / 100,
-          average: Math.round((student3qInfo?.rq.average ?? 0) * 100) / 100,
-          percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
-        },
-        {
-          title: "Creative Quotient (CQ)",
-          category: "CQ" as "LQ" | "RQ" | "CQ",
-          description: "교류 능력 지수",
-          score: Math.round((student3qInfo?.cq.score ?? 0) * 100) / 100,
-          average: Math.round((student3qInfo?.cq.average ?? 0) * 100) / 100,
-          percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
-        },
-      ];
+    {
+      title: "Learning Quotient (LQ)",
+      category: "LQ" as "LQ" | "RQ" | "CQ",
+      description: "학습 능력 지수",
+      score: Math.round((student3qInfo?.lq.score ?? 0) * 100) / 100,
+      average: Math.round((student3qInfo?.lq.average ?? 0) * 100) / 100,
+      percentage: Math.round((student3qInfo?.lq.percentile ?? 0) * 100),
+    },
+    {
+      title: "Research Quotient (RQ)",
+      category: "RQ" as "LQ" | "RQ" | "CQ",
+      description: "연구 능력 지수",
+      score: Math.round((student3qInfo?.rq.score ?? 0) * 100) / 100,
+      average: Math.round((student3qInfo?.rq.average ?? 0) * 100) / 100,
+      percentage: Math.round((student3qInfo?.rq.percentile ?? 0) * 100),
+    },
+    {
+      title: "Creative Quotient (CQ)",
+      category: "CQ" as "LQ" | "RQ" | "CQ",
+      description: "교류 능력 지수",
+      score: Math.round((student3qInfo?.cq.score ?? 0) * 100) / 100,
+      average: Math.round((student3qInfo?.cq.average ?? 0) * 100) / 100,
+      percentage: Math.round((student3qInfo?.cq.percentile ?? 0) * 100),
+    },
+  ];
 
   // 3Q 변화 데이터
   const lineChartData =
@@ -300,7 +300,7 @@ const StudentDashboard: React.FC = () => {
         {/* 3Q 통계 */}
         <div css={{ width: "100%" }}>
           <div css={sectionHeaderStyle}>
-            <h2 css={subtitleStyle}>3Q 지표 요약</h2>
+          <h2 css={subtitleStyle}>3Q 지표 요약</h2>
             <div css={toggleContainerStyle}>
               <span css={toggleLabelStyle}>T-점수 보기</span>
               <button

--- a/src/stores/selectedUserStore.ts
+++ b/src/stores/selectedUserStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-interface User {
+export interface SelectedUser {
   id: number;
   name: string;
   department: string;
@@ -9,6 +9,10 @@ interface User {
   rq: number;
   cq: number;
   totalScore: number;
+  tlq?: number;
+  trq?: number;
+  tcq?: number;
+  totalTScore?: number;
 }
 
 interface Averages {
@@ -16,26 +20,34 @@ interface Averages {
   averageRQ: number;
   averageCQ: number;
   averageTotal: number;
+  averageTLQ: number;
+  averageTRQ: number;
+  averageTCQ: number;
+  averageTTotal: number;
 }
 
 interface SelectedUserStore {
-  selectedUsers: User[];
+  selectedUsers: SelectedUser[];
   averages: Averages;
-  addUser: (user: User) => void;
+  addUser: (user: SelectedUser) => void;
   removeUser: (userId: number) => void;
-  setUsers: (users: User[]) => void;
+  setUsers: (users: SelectedUser[]) => void;
   clearUsers: () => void;
   isUserSelected: (userId: number) => boolean;
   calculateAverages: () => void;
 }
 
-const calculateAverages = (users: User[]): Averages => {
+const calculateAverages = (users: SelectedUser[]): Averages => {
   if (users.length === 0) {
     return {
       averageLQ: 0,
       averageRQ: 0,
       averageCQ: 0,
       averageTotal: 0,
+      averageTLQ: 0,
+      averageTRQ: 0,
+      averageTCQ: 0,
+      averageTTotal: 0,
     };
   }
 
@@ -44,11 +56,20 @@ const calculateAverages = (users: User[]): Averages => {
   const sumCQ = users.reduce((acc, user) => acc + user.cq, 0);
   const sumTotal = users.reduce((acc, user) => acc + user.totalScore, 0);
 
+  const sumTLQ = users.reduce((acc, user) => acc + (user.tlq || 0), 0);
+  const sumTRQ = users.reduce((acc, user) => acc + (user.trq || 0), 0);
+  const sumTCQ = users.reduce((acc, user) => acc + (user.tcq || 0), 0);
+  const sumTTotal = users.reduce((acc, user) => acc + (user.totalTScore || 0), 0);
+
   return {
     averageLQ: Math.round((sumLQ / users.length) * 100) / 100,
     averageRQ: Math.round((sumRQ / users.length) * 100) / 100,
     averageCQ: Math.round((sumCQ / users.length) * 100) / 100,
     averageTotal: Math.round((sumTotal / users.length) * 100) / 100,
+    averageTLQ: Math.round((sumTLQ / users.length) * 100) / 100,
+    averageTRQ: Math.round((sumTRQ / users.length) * 100) / 100,
+    averageTCQ: Math.round((sumTCQ / users.length) * 100) / 100,
+    averageTTotal: Math.round((sumTTotal / users.length) * 100) / 100,
   };
 };
 
@@ -59,9 +80,13 @@ export const useSelectedUserStore = create<SelectedUserStore>((set, get) => ({
     averageRQ: 0,
     averageCQ: 0,
     averageTotal: 0,
+    averageTLQ: 0,
+    averageTRQ: 0,
+    averageTCQ: 0,
+    averageTTotal: 0,
   },
 
-  addUser: (user: User) => {
+  addUser: (user: SelectedUser) => {
     const { selectedUsers } = get();
     if (!selectedUsers.find((u) => u.id === user.id)) {
       const newUsers = [...selectedUsers, user];
@@ -77,7 +102,7 @@ export const useSelectedUserStore = create<SelectedUserStore>((set, get) => ({
     set({ selectedUsers: newUsers, averages: newAverages });
   },
 
-  setUsers: (users: User[]) => {
+  setUsers: (users: SelectedUser[]) => {
     const newAverages = calculateAverages(users);
     set({ selectedUsers: users, averages: newAverages });
   },
@@ -90,6 +115,10 @@ export const useSelectedUserStore = create<SelectedUserStore>((set, get) => ({
         averageRQ: 0,
         averageCQ: 0,
         averageTotal: 0,
+        averageTLQ: 0,
+        averageTRQ: 0,
+        averageTCQ: 0,
+        averageTTotal: 0,
       },
     });
   },

--- a/src/utils/normalDistribution.ts
+++ b/src/utils/normalDistribution.ts
@@ -1,0 +1,63 @@
+/**
+ * 정규분포 확률밀도함수(PDF) 계산
+ * @param x - 계산할 x 값
+ * @param mean - 평균 (μ)
+ * @param stdDev - 표준편차 (σ)
+ * @returns 확률밀도 값
+ */
+export const normalPDF = (x: number, mean: number, stdDev: number): number => {
+  const coefficient = 1 / (stdDev * Math.sqrt(2 * Math.PI));
+  const exponent = -Math.pow(x - mean, 2) / (2 * Math.pow(stdDev, 2));
+  return coefficient * Math.exp(exponent);
+};
+
+/**
+ * 정규분포 곡선 데이터 생성
+ * @param mean - 평균
+ * @param stdDev - 표준편차
+ * @param points - 생성할 데이터 포인트 개수
+ * @param range - 평균으로부터의 표준편차 범위
+ * @returns {x, y}[] 형태의 데이터 배열
+ */
+export const generateNormalDistributionData = (
+  mean: number = 50,
+  stdDev: number = 10,
+  points: number = 100,
+  range: number = 4
+): { x: number; y: number }[] => {
+  const start = mean - range * stdDev;
+  const end = mean + range * stdDev;
+  const step = (end - start) / points;
+
+  const data: { x: number; y: number }[] = [];
+  for (let i = 0; i <= points; i++) {
+    const x = start + i * step;
+    const y = normalPDF(x, mean, stdDev);
+    data.push({ x: Math.round(x * 100) / 100, y: Math.round(y * 10000) / 10000 });
+  }
+
+  return data;
+};
+
+/**
+ * T-점수를 백분위로 변환 (근사값)
+ * @param tScore - T-점수
+ * @returns 백분위 (0-100)
+ */
+export const tScoreToPercentile = (tScore: number): number => {
+  // Z-score 계산 (T-score = 50 + 10*Z)
+  const z = (tScore - 50) / 10;
+  
+  // 누적분포함수(CDF) 근사 계산 (Zelen & Severo 근사)
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989423 * Math.exp(-z * z / 2);
+  const probability =
+    d *
+    t *
+    (0.3193815 +
+      t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+
+  const percentile = z >= 0 ? (1 - probability) * 100 : probability * 100;
+  return Math.round(percentile * 100) / 100;
+};
+


### PR DESCRIPTION
## 📌 PR 개요

간단한 요약을 적어주세요 (예: 어떤 기능을 추가했는지, 어떤 문제를 해결했는지 등)

## 🛠 작업 내용

<img width="1092" height="929" alt="image" src="https://github.com/user-attachments/assets/66364af0-8599-4a2b-be5f-a63dd48e7c65" />
<img width="1092" height="929" alt="image" src="https://github.com/user-attachments/assets/af56c12d-3aa5-4037-809c-76a92136ff7f" />

- [ ] 학생 대시보드의 '나의 분포' 추가, 2가지 정규분포

<img width="528" height="670" alt="image" src="https://github.com/user-attachments/assets/a906a5ae-6442-46f4-b487-394357b73b19" />

- [ ] 점수 T점수로 보기 토글 추가 (여기 게이지와 t점수 시의 백분위가 다른데, 원인 분석 필요)


<img width="1092" height="929" alt="image" src="https://github.com/user-attachments/assets/17d3ed13-67f6-4f5a-aa2b-12a6a8c679b2" />

- [ ] 관리자 개인별 통계의 레이아웃 수정(그래프를 메인으로)
- [ ] T점수 보기 토글 시 모든 점수가 T점수로 보임
- [ ] T점수로 보기 상태의 경우 T점수 합계 칼럼이 그래프에 추가 되고 y값 범위가 조정됨.

## 🖼 스크린샷 (선택)

## 🔗 연관된 이슈

- closes #이슈번호
